### PR TITLE
Use correct OAuth flow scopes

### DIFF
--- a/internal/converter/gnostic/convertions.go
+++ b/internal/converter/gnostic/convertions.go
@@ -161,7 +161,7 @@ func toSecuritySchemes(s *goa3.SecuritySchemesOrReferences) *orderedmap.Map[stri
 				}
 				if secScheme.Flows.ClientCredentials != nil {
 					scopes := orderedmap.New[string, string]()
-					for _, scope := range secScheme.Flows.Password.Scopes.AdditionalProperties {
+					for _, scope := range secScheme.Flows.ClientCredentials.Scopes.AdditionalProperties {
 						scopes.Set(scope.Name, scope.Value)
 					}
 					flows.ClientCredentials = &v3.OAuthFlow{
@@ -172,7 +172,7 @@ func toSecuritySchemes(s *goa3.SecuritySchemesOrReferences) *orderedmap.Map[stri
 				}
 				if secScheme.Flows.AuthorizationCode != nil {
 					scopes := orderedmap.New[string, string]()
-					for _, scope := range secScheme.Flows.Password.Scopes.AdditionalProperties {
+					for _, scope := range secScheme.Flows.AuthorizationCode.Scopes.AdditionalProperties {
 						scopes.Set(scope.Name, scope.Value)
 					}
 					flows.AuthorizationCode = &v3.OAuthFlow{


### PR DESCRIPTION
Previous code referred to the oauth password scope for all cases, so here we update to reference the correct flow type when building scopes. Without this change I was seeing a panic if I tried to specify an OAuth2 client credentials flow in gnostic configuration. I tried to find somewhere to add a test case that would fail but I couldn't seem to trigger one from `converter_test.go` but happy to add a test case if you can maybe steer me in the right direction