### PR TITLE
Render security scheme type

### DIFF
--- a/internal/converter/fixtures/output/gnostic.openapi.json
+++ b/internal/converter/fixtures/output/gnostic.openapi.json
@@ -273,6 +273,7 @@
     },
     "securitySchemes": {
       "BasicAuth": {
+        "type": "http",
         "scheme": "basic"
       }
     }

--- a/internal/converter/fixtures/output/gnostic.openapi.yaml
+++ b/internal/converter/fixtures/output/gnostic.openapi.yaml
@@ -182,6 +182,7 @@ components:
             $ref: '#/components/schemas/connect'
   securitySchemes:
     BasicAuth:
+      type: http
       scheme: basic
 security: []
 tags:

--- a/internal/converter/gnostic/convertions.go
+++ b/internal/converter/gnostic/convertions.go
@@ -125,7 +125,9 @@ func toSecuritySchemes(s *goa3.SecuritySchemesOrReferences) *orderedmap.Map[stri
 	for _, addProp := range s.AdditionalProperties {
 		secScheme := addProp.Value.GetSecurityScheme()
 		if secScheme != nil {
-			scheme := &v3.SecurityScheme{}
+			scheme := &v3.SecurityScheme{
+				Type: secScheme.Type,
+			}
 			switch secScheme.Type {
 			case "http":
 				scheme.Scheme = secScheme.Scheme


### PR DESCRIPTION
Ensure the type field on security scheme annotation makes it to the rendered openapi. 

Again very possible/probable that I might be missing something, but I think that `type` field is required in the OpenAPI schema so I think it probably makes sense to make it available to the rendered yaml/json