### PR TITLE
Skip rendering gnostic servers on empty slice

### DIFF
--- a/internal/converter/fixtures/output/gnostic.openapi.json
+++ b/internal/converter/fixtures/output/gnostic.openapi.json
@@ -84,8 +84,7 @@
           {
             "BasicAuth": []
           }
-        ],
-        "servers": []
+        ]
       }
     }
   },

--- a/internal/converter/fixtures/output/gnostic.openapi.yaml
+++ b/internal/converter/fixtures/output/gnostic.openapi.yaml
@@ -48,7 +48,6 @@ paths:
       deprecated: true
       security:
         - BasicAuth: []
-      servers: []
 components:
   schemas:
     example_with_gnostic.HelloReply:

--- a/internal/converter/gnostic/convertions.go
+++ b/internal/converter/gnostic/convertions.go
@@ -12,6 +12,9 @@ import (
 )
 
 func toServers(servers []*goa3.Server) []*v3.Server {
+	if len(servers) == 0 {
+		return nil
+	}
 	result := make([]*v3.Server, len(servers))
 	for i, server := range servers {
 		result[i] = toServer(server)


### PR DESCRIPTION
Without this I found that we generated an empty `servers` list on all operations which meant that my base `servers` list wasn't used, which then meant that my final documentation didn't carry through the server address correctly.