### PR TITLE
fix: updates libopenapi version to v0.16.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bufbuild/protovalidate-go v0.6.2
 	github.com/google/gnostic v0.7.0
 	github.com/lmittmann/tint v1.0.4
-	github.com/pb33f/libopenapi v0.16.8
+	github.com/pb33f/libopenapi v0.16.9
 	github.com/pb33f/libopenapi-validator v0.0.56
 	github.com/pseudomuto/protokit v0.2.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -849,6 +849,8 @@ github.com/pb33f/libopenapi v0.16.7 h1:kgzBpcX+ESF+C/UUlpqd+H4qdWloBfsDJVMgUmbPD
 github.com/pb33f/libopenapi v0.16.7/go.mod h1:PEXNwvtT4KNdjrwudp5OYnD1ryqK6uJ68aMNyWvoMuc=
 github.com/pb33f/libopenapi v0.16.8 h1:EceJ+JTHViwjKNyP3LJ8J39jSQ4F2oOvHw6KfWCcVxM=
 github.com/pb33f/libopenapi v0.16.8/go.mod h1:PEXNwvtT4KNdjrwudp5OYnD1ryqK6uJ68aMNyWvoMuc=
+github.com/pb33f/libopenapi v0.16.9 h1:S9/w9enIiMK7d99rKbSH74GrNpbk93dAh0SBGIzzO14=
+github.com/pb33f/libopenapi v0.16.9/go.mod h1:CnxtjayCuW9/4TgXDnZu0reM+FvowTqOhvpRB22Zd4k=
 github.com/pb33f/libopenapi-validator v0.0.56 h1:kYO8DRsSRpnxhUExuEfsgARuT/hkc/ISC77CX0BMze4=
 github.com/pb33f/libopenapi-validator v0.0.56/go.mod h1:Cwdf0GUmnUrbw1LBpcGV1Wx5q/LC9akREV4Jc6/yJDc=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=


### PR DESCRIPTION
i was running into a panic attempting to generate from some basic protobuf with an almost empty protobuf message. digging into the panic, turns out there was a fix for this in https://github.com/pb33f/libopenapi/issues/301 that was released yesterday.

cloned the repository, updated the libopenapi to the latest, and i was able to generate from my example! here is the panic i was getting for context:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10326c940]

goroutine 1 [running]:
github.com/pb33f/libopenapi/datamodel/high.(*NodeBuilder).AddYAMLNode(0x140003ecdc0, 0x14000379540, 0x140001312c0)
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/pb33f/libopenapi@v0.16.8/datamodel/high/node_builder.go:397 +0xe80
github.com/pb33f/libopenapi/datamodel/high.(*NodeBuilder).Render(0x140003ecdc0)
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/pb33f/libopenapi@v0.16.8/datamodel/high/node_builder.go:259 +0x234
github.com/pb33f/libopenapi/datamodel/high/v3.(*Document).RenderJSON(0x140000021c0?, {0x1033872b6, 0x2})
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/pb33f/libopenapi@v0.16.8/datamodel/high/v3/document.go:177 +0x44
github.com/sudorandom/protoc-gen-connect-openapi/internal/converter.specToFile({{0x0, 0x0}, {0x1033875ce, 0x4}, {0x1400013a785, 0x17}, 0x0, 0x0, 0x1400047bd70, _, ...}, ...)
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/sudorandom/protoc-gen-connect-openapi@v0.8.5-0.20240703195406-7153fcf8900c/internal/converter/converter.go:238 +0x104
github.com/sudorandom/protoc-gen-connect-openapi/internal/converter.Convert(0x140001a1080)
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/sudorandom/protoc-gen-connect-openapi@v0.8.5-0.20240703195406-7153fcf8900c/internal/converter/converter.go:215 +0xc60
github.com/sudorandom/protoc-gen-connect-openapi/internal/converter.ConvertFrom({0x10360e338?, 0x1400011c040?})
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/sudorandom/protoc-gen-connect-openapi@v0.8.5-0.20240703195406-7153fcf8900c/internal/converter/converter.go:108 +0xfc
main.main()
        /Users/dylanboss/.local/share/mise/installs/go/latest/pkg/mod/github.com/sudorandom/protoc-gen-connect-openapi@v0.8.5-0.20240703195406-7153fcf8900c/main.go:15 +0x30
Failure: plugin protoc-gen-connect-openapi: exit status 2
```