### PR TITLE
fix: check for nil example

### DIFF
--- a/internal/converter/gnostic/convertions.go
+++ b/internal/converter/gnostic/convertions.go
@@ -368,6 +368,10 @@ func toHeaders(v *goa3.HeadersOrReferences) *orderedmap.Map[string, *v3.Header] 
 	headers := orderedmap.New[string, *v3.Header]()
 	for _, headerVal := range v.GetAdditionalProperties() {
 		header := headerVal.Value.GetHeader()
+		var exampleRawInfo *yaml.Node
+		if header.Example != nil {
+			exampleRawInfo = header.Example.ToRawInfo()
+		}
 		headers.Set(headerVal.Name, &v3.Header{
 			Description:     header.Description,
 			Required:        header.Required,
@@ -377,7 +381,7 @@ func toHeaders(v *goa3.HeadersOrReferences) *orderedmap.Map[string, *v3.Header] 
 			Explode:         header.Explode,
 			AllowReserved:   header.AllowReserved,
 			Schema:          toSchemaOrReference(header.Schema),
-			Example:         header.Example.ToRawInfo(),
+			Example:         exampleRawInfo,
 			Examples:        toExamples(header.GetExamples()),
 			Content:         toMediaTypes(header.Content),
 			Extensions:      toExtensions(header.GetSpecificationExtension()),


### PR DESCRIPTION
Hi I had a panic with a nil pointer dereference when trying to set a Header without an example.

Here is a fix that checks the existance of the example before getting the raw info. (maybe the issue is more on the gnostic side, but since it's some generated code, I don't know how to work with it).

Here is an example that does the panic.

```proto
syntax = "proto3";
package auth.login;

option go_package = "gen/auth";

import "gnostic/openapi/v3/annotations.proto";

service AuthService {
    rpc Login(LoginRequest) returns (LoginResponse) {
        option (gnostic.openapi.v3.operation) = {
            responses: {
                response_or_reference: [{
                    name: "200",
                    value: {
                        response: {
                            description: "Login success"
                            headers: {
                                additional_properties: [{
                                    name: "Set-Cookie"
                                    value: {
                                        header: {
                                            description: "header description"
                                            /* if this is commented, it panics
                                            example: {
                                                yaml: "header example"
                                            }
                                            */
                                            schema: {
                                                schema: {
                                                    type: "string"
                                                    example: {
                                                        yaml: "schema example"
                                                    }
                                                }
                                            }
                                        }
                                    }
                                }]
                            }
                        }
                    }
                }]
            },
            security: [
                {
                    additional_properties: []
                }
            ]
        };
    };
}

message LoginRequest {
    string username = 1;
    string password = 2;
}

message LoginResponse {
    bool success = 1;
}
```