### PR TITLE
Add mutualTLS security scheme

### DIFF
--- a/internal/converter/gnostic/convertions.go
+++ b/internal/converter/gnostic/convertions.go
@@ -134,6 +134,7 @@ func toSecuritySchemes(s *goa3.SecuritySchemesOrReferences) *orderedmap.Map[stri
 				Type: secScheme.Type,
 			}
 			switch secScheme.Type {
+			case "mutualTLS":
 			case "http":
 				scheme.Scheme = secScheme.Scheme
 			case "apiKey":


### PR DESCRIPTION
Thanks for this plugin!

I'm looking to add the `mutualTLS` security scheme to the list of valid security schemes.

OpenAPI 3.1 supports setting this security scheme type:

- https://spec.openapis.org/oas/v3.1.0#security-scheme-object
- https://learn.openapis.org/specification/security.html#mutual-tls