### PR TITLE
Add option for ignoring googleapi http paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ protoc-gen-connect-openapi also has support for the [OpenAPI v3 annotations](htt
 | debug | - | Emit debug logs |
 | format | `yaml` or `json` | Which format to use for the OpenAPI file, defaults to `yaml`. |
 | include-number-enum-values | - | Include number enum values beside the string versions, defaults to only showing strings |
+| ignore-googleapi-http | - | Ignore `google.api.http` options on methods when generating openapi specs  |
 | path | `{filepath}` | Output filepath, defaults to per-protofile output if not given. |
 | proto | - | Generate requests/repsonses with the protobuf content type |
 | trim-unused-types | - | Remove types that aren't references from any method request or response. |

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -155,6 +155,14 @@ func WithIncludeNumberEnumValues(includeNumberEnumValues bool) Option {
 	}
 }
 
+// WithIgnoreGoogleapiHTTP tells the generator to ignore google.api.http options.
+func WithIgnoreGoogleapiHTTP(ignoreGoogleapiHTTP bool) Option {
+	return func(g *generator) error {
+		g.options.IgnoreGoogleapiHTTP = ignoreGoogleapiHTTP
+		return nil
+	}
+}
+
 // WithStreaming sets a file to use as a base for all OpenAPI files.
 func WithStreaming(streaming bool) Option {
 	return func(g *generator) error {

--- a/internal/converter/googleapi/paths.go
+++ b/internal/converter/googleapi/paths.go
@@ -18,6 +18,9 @@ import (
 )
 
 func MakePathItems(opts options.Options, md protoreflect.MethodDescriptor) *orderedmap.Map[string, *v3.PathItem] {
+	if opts.IgnoreGoogleapiHTTP {
+		return nil
+	}
 	mdopts := md.Options()
 	if !proto.HasExtension(mdopts, annotations.E_Http) {
 		return nil

--- a/internal/converter/options/options.go
+++ b/internal/converter/options/options.go
@@ -38,6 +38,8 @@ type Options struct {
 	FullyQualifiedMessageNames bool
 	// WithServiceDescriptions set to true will cause service names and their comments to be added to the end of info.description.
 	WithServiceDescriptions bool
+	// IgnoreGoogleapiHTTP set to true will cause service to always generate OpenAPI specs for connect endpoints, and ignore any google.api.http options.
+	IgnoreGoogleapiHTTP bool
 	// Services filters which services will be used for generating OpenAPI spec.
 	Services []protoreflect.FullName
 
@@ -97,6 +99,8 @@ func FromString(s string) (Options, error) {
 			opts.FullyQualifiedMessageNames = true
 		case param == "with-service-descriptions":
 			opts.WithServiceDescriptions = true
+		case param == "ignore-googleapi-http":
+			opts.IgnoreGoogleapiHTTP = true
 		case strings.HasPrefix(param, "content-types="):
 			for _, contentType := range strings.Split(param[14:], ";") {
 				contentType = strings.TrimSpace(contentType)


### PR DESCRIPTION
Adds an option to ignore googleapi http options. We have various cases where not all routes are exposed everywhere, so it can be more helpful to just point to connect paths instead, especially in development.

Not sure if this simple "ignore http" option is preferred or one where the plugin generates both connect and http paths.

Apologies if this is not the correct way to contribute. Was going to raise an issue but before long I had this working.
