### PR TITLE
Improve gnostic handling of methods

### DIFF
--- a/internal/converter/paths.go
+++ b/internal/converter/paths.go
@@ -37,7 +37,8 @@ func addPathItemsFromFile(opts options.Options, fd protoreflect.FileDescriptor, 
 
 			// Update path items from google.api annotations
 			for pair := pathItems.First(); pair != nil; pair = pair.Next() {
-				addPathItem(pair.Key(), pair.Value())
+				item := gnostic.PathItemWithMethodAnnotations(pair.Value(), method)
+				addPathItem(pair.Key(), item)
 			}
 
 			// Default to ConnectRPC/gRPC path if no google.api annotations


### PR DESCRIPTION
For my use case I was looking for the ability to change the default error object being returned. While I love connect having return types that convert to "any" in TypeScript is a problem -- so I provide my own wrapper. 

I noticed two issues with the handling of gnostic meta data. 
1. It was not being annotated onto APIs that had `option (google.api.http)` set, which made setting a default return difficult
2. the handling of responseorreference was incomplete, since my default assumption was that i could just set `default: { reference { _ref: " .... " } } }`

This PR addresses these issues