### PR TITLE
fix: handle presence for oneof fields in schema conversion

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# use this Dockerfile to install additional tools you might need, e.g.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// The Dev Container format allows you to configure your environment. At the heart of it
+// is a Docker image or Dockerfile which controls the tools available in your environment.
+//
+// See https://aka.ms/devcontainer.json for more information.
+{
+  "name": "Gitpod",
+  // Use "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  // instead of the build to use a pre-built image.
+  "build": {
+    "context": ".",
+    "dockerfile": "Dockerfile"
+  },
+  // Features add additional features to your environment. See https://containers.dev/features
+  // Beware: features are not supported on all platforms and may have unintended side-effects.
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {}
+  }
+}

--- a/internal/converter/schema/schema.go
+++ b/internal/converter/schema/schema.go
@@ -39,10 +39,15 @@ func MessageToSchema(opts options.Options, tt protoreflect.MessageDescriptor) (s
 	fields := tt.Fields()
 	for i := 0; i < fields.Len(); i++ {
 		field := fields.Get(i)
-		if oneOf := field.ContainingOneof(); oneOf != nil {
+		if oneOf := field.ContainingOneof(); oneOf != nil && !oneOf.IsSynthetic() {
 			oneOneGroups[oneOf.FullName()] = append(oneOneGroups[oneOf.FullName()], util.MakeFieldName(opts, field))
 		}
-		props.Set(util.MakeFieldName(opts, field), FieldToSchema(opts, base.CreateSchemaProxy(s), field))
+		prop := FieldToSchema(opts, base.CreateSchemaProxy(s), field)
+		if field.HasOptionalKeyword() {
+			nullable := true
+			prop.Schema().Nullable = &nullable
+		}
+		props.Set(util.MakeFieldName(opts, field), prop)
 	}
 
 	s.Properties = props

--- a/internal/converter/testdata/standard/output/flex.openapi.json
+++ b/internal/converter/testdata/standard/output/flex.openapi.json
@@ -620,24 +620,6 @@
     "schemas": {
       "flex.ComplexType": {
         "type": "object",
-        "anyOf": [
-          {
-            "required": [
-              "optionalMsgField"
-            ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "optionalMsgField"
-                  ]
-                }
-              ]
-            }
-          }
-        ],
         "properties": {
           "doubleField": {
             "type": "number",
@@ -741,7 +723,8 @@
                 "$ref": "#/components/schemas/flex.Other"
               }
             ],
-            "title": "optionalMsgField"
+            "title": "optionalMsgField",
+            "nullable": true
           }
         },
         "title": "ComplexType",

--- a/internal/converter/testdata/standard/output/flex.openapi.yaml
+++ b/internal/converter/testdata/standard/output/flex.openapi.yaml
@@ -379,13 +379,6 @@ components:
   schemas:
     flex.ComplexType:
       type: object
-      anyOf:
-        - required:
-            - optionalMsgField
-        - not:
-            anyOf:
-              - required:
-                  - optionalMsgField
       properties:
         doubleField:
           type: number
@@ -462,6 +455,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/flex.Other'
           title: optionalMsgField
+          nullable: true
       title: ComplexType
       additionalProperties: false
       description: Type that has a bunch of different types

--- a/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.json
@@ -1455,24 +1455,6 @@
       },
       "buf.validate.conformance.cases.Int64LTEOptional": {
         "type": "object",
-        "anyOf": [
-          {
-            "required": [
-              "val"
-            ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "val"
-                  ]
-                }
-              ]
-            }
-          }
-        ],
         "properties": {
           "val": {
             "type": [
@@ -1481,7 +1463,8 @@
             ],
             "title": "val",
             "maximum": 64,
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           }
         },
         "title": "Int64LTEOptional",

--- a/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.yaml
@@ -1097,13 +1097,6 @@ components:
       additionalProperties: false
     buf.validate.conformance.cases.Int64LTEOptional:
       type: object
-      anyOf:
-        - required:
-            - val
-        - not:
-            anyOf:
-              - required:
-                  - val
       properties:
         val:
           type:
@@ -1112,6 +1105,7 @@ components:
           title: val
           maximum: 64
           format: int64
+          nullable: true
       title: Int64LTEOptional
       additionalProperties: false
     buf.validate.conformance.cases.Int64None:

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.json
@@ -275,334 +275,13 @@
       },
       "protovalidate.LotsOfValidationRules": {
         "type": "object",
-        "allOf": [
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "byteLen"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "byteLen"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesContains"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesContains"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesIn"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesIn"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesIp"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesIp"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesIpv4"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesIpv4"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesIpv6"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesIpv6"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesMaxLen"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesMaxLen"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesMinLen"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesMinLen"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesNotIn"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesNotIn"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesPattern"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesPattern"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesPrefix"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesPrefix"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "bytesSuffix"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "bytesSuffix"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "celField"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "celField"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "requiredField"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "requiredField"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "skippedField"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "skippedField"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "anyOf": [
-              {
-                "required": [
-                  "uriField"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "uriField"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ],
         "properties": {
           "celField": {
             "type": "integer",
             "title": "cel_field",
             "format": "int32",
-            "description": "value must be greater than 42:\n```\nthis \u003e 42\n```\n\n"
+            "description": "value must be greater than 42:\n```\nthis \u003e 42\n```\n\n",
+            "nullable": true
           },
           "skippedField": {
             "allOf": [
@@ -610,7 +289,8 @@
                 "$ref": "#/components/schemas/protovalidate.MyOtherMessage"
               }
             ],
-            "title": "skipped_field"
+            "title": "skipped_field",
+            "nullable": true
           },
           "requiredField": {
             "allOf": [
@@ -618,12 +298,14 @@
                 "$ref": "#/components/schemas/protovalidate.MyOtherMessage"
               }
             ],
-            "title": "required_field"
+            "title": "required_field",
+            "nullable": true
           },
           "uriField": {
             "type": "string",
             "title": "uri_field",
-            "format": "uri"
+            "format": "uri",
+            "nullable": true
           },
           "floatConst": {
             "type": "number",
@@ -1720,40 +1402,47 @@
             "title": "byte_len",
             "maxLength": 4,
             "minLength": 4,
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesMinLen": {
             "type": "string",
             "title": "bytes_min_len",
             "minLength": 2,
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesMaxLen": {
             "type": "string",
             "title": "bytes_max_len",
             "maxLength": 6,
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesPattern": {
             "type": "string",
             "title": "bytes_pattern",
             "pattern": "^[a-zA-Z0-9]+$",
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesPrefix": {
             "type": "string",
             "title": "bytes_prefix",
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesSuffix": {
             "type": "string",
             "title": "bytes_suffix",
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesContains": {
             "type": "string",
             "title": "bytes_contains",
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesIn": {
             "type": "string",
@@ -1763,7 +1452,8 @@
               "\u0001\u0002",
               "\u0002\u0003",
               "\u0003\u0004"
-            ]
+            ],
+            "nullable": true
           },
           "bytesNotIn": {
             "type": "string",
@@ -1776,22 +1466,26 @@
               ]
             },
             "title": "bytes_not_in",
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "bytesIp": {
             "type": "string",
             "title": "bytes_ip",
-            "format": "ip"
+            "format": "ip",
+            "nullable": true
           },
           "bytesIpv4": {
             "type": "string",
             "title": "bytes_ipv4",
-            "format": "ipv4"
+            "format": "ipv4",
+            "nullable": true
           },
           "bytesIpv6": {
             "type": "string",
             "title": "bytes_ipv6",
-            "format": "ipv6"
+            "format": "ipv6",
+            "nullable": true
           },
           "enumConst": {
             "allOf": [

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
@@ -328,119 +328,6 @@ components:
       additionalProperties: false
     protovalidate.LotsOfValidationRules:
       type: object
-      allOf:
-        - anyOf:
-            - required:
-                - byteLen
-            - not:
-                anyOf:
-                  - required:
-                      - byteLen
-        - anyOf:
-            - required:
-                - bytesContains
-            - not:
-                anyOf:
-                  - required:
-                      - bytesContains
-        - anyOf:
-            - required:
-                - bytesIn
-            - not:
-                anyOf:
-                  - required:
-                      - bytesIn
-        - anyOf:
-            - required:
-                - bytesIp
-            - not:
-                anyOf:
-                  - required:
-                      - bytesIp
-        - anyOf:
-            - required:
-                - bytesIpv4
-            - not:
-                anyOf:
-                  - required:
-                      - bytesIpv4
-        - anyOf:
-            - required:
-                - bytesIpv6
-            - not:
-                anyOf:
-                  - required:
-                      - bytesIpv6
-        - anyOf:
-            - required:
-                - bytesMaxLen
-            - not:
-                anyOf:
-                  - required:
-                      - bytesMaxLen
-        - anyOf:
-            - required:
-                - bytesMinLen
-            - not:
-                anyOf:
-                  - required:
-                      - bytesMinLen
-        - anyOf:
-            - required:
-                - bytesNotIn
-            - not:
-                anyOf:
-                  - required:
-                      - bytesNotIn
-        - anyOf:
-            - required:
-                - bytesPattern
-            - not:
-                anyOf:
-                  - required:
-                      - bytesPattern
-        - anyOf:
-            - required:
-                - bytesPrefix
-            - not:
-                anyOf:
-                  - required:
-                      - bytesPrefix
-        - anyOf:
-            - required:
-                - bytesSuffix
-            - not:
-                anyOf:
-                  - required:
-                      - bytesSuffix
-        - anyOf:
-            - required:
-                - celField
-            - not:
-                anyOf:
-                  - required:
-                      - celField
-        - anyOf:
-            - required:
-                - requiredField
-            - not:
-                anyOf:
-                  - required:
-                      - requiredField
-        - anyOf:
-            - required:
-                - skippedField
-            - not:
-                anyOf:
-                  - required:
-                      - skippedField
-        - anyOf:
-            - required:
-                - uriField
-            - not:
-                anyOf:
-                  - required:
-                      - uriField
       properties:
         celField:
           type: integer
@@ -452,18 +339,22 @@ components:
             this > 42
             ```
 
+          nullable: true
         skippedField:
           allOf:
             - $ref: '#/components/schemas/protovalidate.MyOtherMessage'
           title: skipped_field
+          nullable: true
         requiredField:
           allOf:
             - $ref: '#/components/schemas/protovalidate.MyOtherMessage'
           title: required_field
+          nullable: true
         uriField:
           type: string
           title: uri_field
           format: uri
+          nullable: true
         floatConst:
           type: number
           title: float_const
@@ -1319,33 +1210,40 @@ components:
           maxLength: 4
           minLength: 4
           format: byte
+          nullable: true
         bytesMinLen:
           type: string
           title: bytes_min_len
           minLength: 2
           format: byte
+          nullable: true
         bytesMaxLen:
           type: string
           title: bytes_max_len
           maxLength: 6
           format: byte
+          nullable: true
         bytesPattern:
           type: string
           title: bytes_pattern
           pattern: ^[a-zA-Z0-9]+$
           format: byte
+          nullable: true
         bytesPrefix:
           type: string
           title: bytes_prefix
           format: byte
+          nullable: true
         bytesSuffix:
           type: string
           title: bytes_suffix
           format: byte
+          nullable: true
         bytesContains:
           type: string
           title: bytes_contains
           format: byte
+          nullable: true
         bytesIn:
           type: string
           title: bytes_in
@@ -1354,6 +1252,7 @@ components:
             - "\x01\x02"
             - "\x02\x03"
             - "\x03\x04"
+          nullable: true
         bytesNotIn:
           type: string
           not:
@@ -1364,18 +1263,22 @@ components:
               - "\x03\x04"
           title: bytes_not_in
           format: byte
+          nullable: true
         bytesIp:
           type: string
           title: bytes_ip
           format: ip
+          nullable: true
         bytesIpv4:
           type: string
           title: bytes_ipv4
           format: ipv4
+          nullable: true
         bytesIpv6:
           type: string
           title: bytes_ipv6
           format: ipv6
+          nullable: true
         enumConst:
           allOf:
             - $ref: '#/components/schemas/protovalidate.MyEnum'

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.json
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.json
@@ -2821,29 +2821,34 @@
             "type": "integer",
             "title": "file_index",
             "format": "int32",
-            "description": "File name index, which can be used to retrieve the file name string from\n `files`. The value should be between 0 and (len(files)-1)"
+            "description": "File name index, which can be used to retrieve the file name string from\n `files`. The value should be between 0 and (len(files)-1)",
+            "nullable": true
           },
           "line": {
             "type": "integer",
             "title": "line",
             "format": "int32",
-            "description": "Line number in the file."
+            "description": "Line number in the file.",
+            "nullable": true
           },
           "col": {
             "type": "integer",
             "title": "col",
             "format": "int32",
-            "description": "Col number in the file line."
+            "description": "Col number in the file line.",
+            "nullable": true
           },
           "func": {
             "type": "string",
             "title": "func",
-            "description": "Name of function contains the file line."
+            "description": "Name of function contains the file line.",
+            "nullable": true
           },
           "code": {
             "type": "string",
             "title": "code",
-            "description": "Source code contained in this file line."
+            "description": "Source code contained in this file line.",
+            "nullable": true
           }
         },
         "title": "FileLineCol",
@@ -2859,7 +2864,8 @@
               "string"
             ],
             "title": "key",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "value": {
             "allOf": [
@@ -2867,7 +2873,8 @@
                 "$ref": "#/components/schemas/tensorflow.GraphDebugInfo.FileLineCol"
               }
             ],
-            "title": "value"
+            "title": "value",
+            "nullable": true
           }
         },
         "title": "FramesByIdEntry",
@@ -2878,7 +2885,8 @@
         "properties": {
           "key": {
             "type": "string",
-            "title": "key"
+            "title": "key",
+            "nullable": true
           },
           "value": {
             "type": [
@@ -2886,7 +2894,8 @@
               "string"
             ],
             "title": "value",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           }
         },
         "title": "NameToTraceIdEntry",
@@ -2928,7 +2937,8 @@
               "string"
             ],
             "title": "key",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "value": {
             "allOf": [
@@ -2936,7 +2946,8 @@
                 "$ref": "#/components/schemas/tensorflow.GraphDebugInfo.StackTrace"
               }
             ],
-            "title": "value"
+            "title": "value",
+            "nullable": true
           }
         },
         "title": "TracesByIdEntry",
@@ -2947,7 +2958,8 @@
         "properties": {
           "key": {
             "type": "string",
-            "title": "key"
+            "title": "key",
+            "nullable": true
           },
           "value": {
             "allOf": [
@@ -2955,7 +2967,8 @@
                 "$ref": "#/components/schemas/tensorflow.GraphDebugInfo.StackTrace"
               }
             ],
-            "title": "value"
+            "title": "value",
+            "nullable": true
           }
         },
         "title": "TracesEntry",

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
@@ -2633,24 +2633,29 @@ components:
           description: |-
             File name index, which can be used to retrieve the file name string from
              `files`. The value should be between 0 and (len(files)-1)
+          nullable: true
         line:
           type: integer
           title: line
           format: int32
           description: Line number in the file.
+          nullable: true
         col:
           type: integer
           title: col
           format: int32
           description: Col number in the file line.
+          nullable: true
         func:
           type: string
           title: func
           description: Name of function contains the file line.
+          nullable: true
         code:
           type: string
           title: code
           description: Source code contained in this file line.
+          nullable: true
       title: FileLineCol
       additionalProperties: false
       description: This represents a file/line location in the source code.
@@ -2663,10 +2668,12 @@ components:
             - string
           title: key
           format: int64
+          nullable: true
         value:
           allOf:
             - $ref: '#/components/schemas/tensorflow.GraphDebugInfo.FileLineCol'
           title: value
+          nullable: true
       title: FramesByIdEntry
       additionalProperties: false
     tensorflow.GraphDebugInfo.NameToTraceIdEntry:
@@ -2675,12 +2682,14 @@ components:
         key:
           type: string
           title: key
+          nullable: true
         value:
           type:
             - integer
             - string
           title: value
           format: int64
+          nullable: true
       title: NameToTraceIdEntry
       additionalProperties: false
     tensorflow.GraphDebugInfo.StackTrace:
@@ -2712,10 +2721,12 @@ components:
             - string
           title: key
           format: int64
+          nullable: true
         value:
           allOf:
             - $ref: '#/components/schemas/tensorflow.GraphDebugInfo.StackTrace'
           title: value
+          nullable: true
       title: TracesByIdEntry
       additionalProperties: false
     tensorflow.GraphDebugInfo.TracesEntry:
@@ -2724,10 +2735,12 @@ components:
         key:
           type: string
           title: key
+          nullable: true
         value:
           allOf:
             - $ref: '#/components/schemas/tensorflow.GraphDebugInfo.StackTrace'
           title: value
+          nullable: true
       title: TracesEntry
       additionalProperties: false
     tensorflow.GraphDef:

--- a/internal/converter/testdata/standard/output/test.openapi.json
+++ b/internal/converter/testdata/standard/output/test.openapi.json
@@ -218,526 +218,182 @@
       },
       "test.v1.AllTypes": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optBoolValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optBoolValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "boolOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optBytesValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optBytesValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "bytesOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optDoubleValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optDoubleValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "doubleOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optEnumValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optEnumValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "enumOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optFixed32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optFixed32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "fixed32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optFixed64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optFixed64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "fixed64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optFloatValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optFloatValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "floatOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optInt32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optInt32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "int32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optInt64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optInt64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "int64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optMsgValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optMsgValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "msgOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSfixed32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSfixed32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sfixed32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSfixed64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSfixed64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sfixed64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSint32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSint32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sint32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSint64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSint64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sint64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optStringValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optStringValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "stringOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optUint32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optUint32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "uint32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optUint64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optUint64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "uint64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "boolOption"
-                ]
-              },
-              {
-                "required": [
-                  "bytesOption"
-                ]
-              },
-              {
-                "required": [
-                  "doubleOption"
-                ]
-              },
-              {
-                "required": [
-                  "enumOption"
-                ]
-              },
-              {
-                "required": [
-                  "fixed32Option"
-                ]
-              },
-              {
-                "required": [
-                  "fixed64Option"
-                ]
-              },
-              {
-                "required": [
-                  "floatOption"
-                ]
-              },
-              {
-                "required": [
-                  "int32Option"
-                ]
-              },
-              {
-                "required": [
-                  "int64Option"
-                ]
-              },
-              {
-                "required": [
-                  "msgOption"
-                ]
-              },
-              {
-                "required": [
-                  "sfixed32Option"
-                ]
-              },
-              {
-                "required": [
-                  "sfixed64Option"
-                ]
-              },
-              {
-                "required": [
-                  "sint32Option"
-                ]
-              },
-              {
-                "required": [
-                  "sint64Option"
-                ]
-              },
-              {
-                "required": [
-                  "stringOption"
-                ]
-              },
-              {
-                "required": [
-                  "uint32Option"
-                ]
-              },
-              {
-                "required": [
-                  "uint64Option"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "boolOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bytesOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "doubleOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "enumOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "floatOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "msgOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "stringOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint64Option"
-                      ]
-                    }
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "boolOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "bytesOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "doubleOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "enumOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "floatOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "int32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "int64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "msgOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "stringOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint64Option"
                   ]
                 }
-              }
-            ]
+              ]
+            }
           }
         ],
         "properties": {
@@ -1208,17 +864,20 @@
             "type": "number",
             "title": "opt_double_value",
             "format": "double",
-            "description": "explicit presence types"
+            "description": "explicit presence types",
+            "nullable": true
           },
           "optFloatValue": {
             "type": "number",
             "title": "opt_float_value",
-            "format": "float"
+            "format": "float",
+            "nullable": true
           },
           "optInt32Value": {
             "type": "integer",
             "title": "opt_int32_value",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "optInt64Value": {
             "type": [
@@ -1226,11 +885,13 @@
               "string"
             ],
             "title": "opt_int64_value",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "optUint32Value": {
             "type": "integer",
-            "title": "opt_uint32_value"
+            "title": "opt_uint32_value",
+            "nullable": true
           },
           "optUint64Value": {
             "type": [
@@ -1238,12 +899,14 @@
               "string"
             ],
             "title": "opt_uint64_value",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "optSint32Value": {
             "type": "integer",
             "title": "opt_sint32_value",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "optSint64Value": {
             "type": [
@@ -1251,11 +914,13 @@
               "string"
             ],
             "title": "opt_sint64_value",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "optFixed32Value": {
             "type": "integer",
-            "title": "opt_fixed32_value"
+            "title": "opt_fixed32_value",
+            "nullable": true
           },
           "optFixed64Value": {
             "type": [
@@ -1263,12 +928,14 @@
               "string"
             ],
             "title": "opt_fixed64_value",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "optSfixed32Value": {
             "type": "integer",
             "title": "opt_sfixed32_value",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "optSfixed64Value": {
             "type": [
@@ -1276,20 +943,24 @@
               "string"
             ],
             "title": "opt_sfixed64_value",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "optBoolValue": {
             "type": "boolean",
-            "title": "opt_bool_value"
+            "title": "opt_bool_value",
+            "nullable": true
           },
           "optStringValue": {
             "type": "string",
-            "title": "opt_string_value"
+            "title": "opt_string_value",
+            "nullable": true
           },
           "optBytesValue": {
             "type": "string",
             "title": "opt_bytes_value",
-            "format": "byte"
+            "format": "byte",
+            "nullable": true
           },
           "msgValue": {
             "allOf": [
@@ -1313,7 +984,8 @@
                 "$ref": "#/components/schemas/test.v1.AllTypes"
               }
             ],
-            "title": "opt_msg_value"
+            "title": "opt_msg_value",
+            "nullable": true
           },
           "optEnumValue": {
             "allOf": [
@@ -1321,7 +993,8 @@
                 "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
               }
             ],
-            "title": "opt_enum_value"
+            "title": "opt_enum_value",
+            "nullable": true
           },
           "msgList": {
             "type": "array",

--- a/internal/converter/testdata/standard/output/test.openapi.yaml
+++ b/internal/converter/testdata/standard/output/test.openapi.yaml
@@ -538,197 +538,77 @@ components:
          The JSON representation for `Value` is JSON value.
     test.v1.AllTypes:
       type: object
-      allOf:
-        - anyOf:
-            - required:
-                - optBoolValue
-            - not:
-                anyOf:
-                  - required:
-                      - optBoolValue
-        - anyOf:
-            - required:
-                - optBytesValue
-            - not:
-                anyOf:
-                  - required:
-                      - optBytesValue
-        - anyOf:
-            - required:
-                - optDoubleValue
-            - not:
-                anyOf:
-                  - required:
-                      - optDoubleValue
-        - anyOf:
-            - required:
-                - optEnumValue
-            - not:
-                anyOf:
-                  - required:
-                      - optEnumValue
-        - anyOf:
-            - required:
-                - optFixed32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optFixed32Value
-        - anyOf:
-            - required:
-                - optFixed64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optFixed64Value
-        - anyOf:
-            - required:
-                - optFloatValue
-            - not:
-                anyOf:
-                  - required:
-                      - optFloatValue
-        - anyOf:
-            - required:
-                - optInt32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optInt32Value
-        - anyOf:
-            - required:
-                - optInt64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optInt64Value
-        - anyOf:
-            - required:
-                - optMsgValue
-            - not:
-                anyOf:
-                  - required:
-                      - optMsgValue
-        - anyOf:
-            - required:
-                - optSfixed32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSfixed32Value
-        - anyOf:
-            - required:
-                - optSfixed64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSfixed64Value
-        - anyOf:
-            - required:
-                - optSint32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSint32Value
-        - anyOf:
-            - required:
-                - optSint64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSint64Value
-        - anyOf:
-            - required:
-                - optStringValue
-            - not:
-                anyOf:
-                  - required:
-                      - optStringValue
-        - anyOf:
-            - required:
-                - optUint32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optUint32Value
-        - anyOf:
-            - required:
-                - optUint64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optUint64Value
-        - anyOf:
-            - required:
-                - boolOption
-            - required:
-                - bytesOption
-            - required:
-                - doubleOption
-            - required:
-                - enumOption
-            - required:
-                - fixed32Option
-            - required:
-                - fixed64Option
-            - required:
-                - floatOption
-            - required:
-                - int32Option
-            - required:
-                - int64Option
-            - required:
-                - msgOption
-            - required:
-                - sfixed32Option
-            - required:
-                - sfixed64Option
-            - required:
-                - sint32Option
-            - required:
-                - sint64Option
-            - required:
-                - stringOption
-            - required:
-                - uint32Option
-            - required:
-                - uint64Option
-            - not:
-                anyOf:
-                  - required:
-                      - boolOption
-                  - required:
-                      - bytesOption
-                  - required:
-                      - doubleOption
-                  - required:
-                      - enumOption
-                  - required:
-                      - fixed32Option
-                  - required:
-                      - fixed64Option
-                  - required:
-                      - floatOption
-                  - required:
-                      - int32Option
-                  - required:
-                      - int64Option
-                  - required:
-                      - msgOption
-                  - required:
-                      - sfixed32Option
-                  - required:
-                      - sfixed64Option
-                  - required:
-                      - sint32Option
-                  - required:
-                      - sint64Option
-                  - required:
-                      - stringOption
-                  - required:
-                      - uint32Option
-                  - required:
-                      - uint64Option
+      anyOf:
+        - required:
+            - boolOption
+        - required:
+            - bytesOption
+        - required:
+            - doubleOption
+        - required:
+            - enumOption
+        - required:
+            - fixed32Option
+        - required:
+            - fixed64Option
+        - required:
+            - floatOption
+        - required:
+            - int32Option
+        - required:
+            - int64Option
+        - required:
+            - msgOption
+        - required:
+            - sfixed32Option
+        - required:
+            - sfixed64Option
+        - required:
+            - sint32Option
+        - required:
+            - sint64Option
+        - required:
+            - stringOption
+        - required:
+            - uint32Option
+        - required:
+            - uint64Option
+        - not:
+            anyOf:
+              - required:
+                  - boolOption
+              - required:
+                  - bytesOption
+              - required:
+                  - doubleOption
+              - required:
+                  - enumOption
+              - required:
+                  - fixed32Option
+              - required:
+                  - fixed64Option
+              - required:
+                  - floatOption
+              - required:
+                  - int32Option
+              - required:
+                  - int64Option
+              - required:
+                  - msgOption
+              - required:
+                  - sfixed32Option
+              - required:
+                  - sfixed64Option
+              - required:
+                  - sint32Option
+              - required:
+                  - sint64Option
+              - required:
+                  - stringOption
+              - required:
+                  - uint32Option
+              - required:
+                  - uint64Option
       properties:
         doubleValue:
           type: number
@@ -1084,68 +964,83 @@ components:
           title: opt_double_value
           format: double
           description: explicit presence types
+          nullable: true
         optFloatValue:
           type: number
           title: opt_float_value
           format: float
+          nullable: true
         optInt32Value:
           type: integer
           title: opt_int32_value
           format: int32
+          nullable: true
         optInt64Value:
           type:
             - integer
             - string
           title: opt_int64_value
           format: int64
+          nullable: true
         optUint32Value:
           type: integer
           title: opt_uint32_value
+          nullable: true
         optUint64Value:
           type:
             - integer
             - string
           title: opt_uint64_value
           format: int64
+          nullable: true
         optSint32Value:
           type: integer
           title: opt_sint32_value
           format: int32
+          nullable: true
         optSint64Value:
           type:
             - integer
             - string
           title: opt_sint64_value
           format: int64
+          nullable: true
         optFixed32Value:
           type: integer
           title: opt_fixed32_value
+          nullable: true
         optFixed64Value:
           type:
             - integer
             - string
           title: opt_fixed64_value
           format: int64
+          nullable: true
         optSfixed32Value:
           type: integer
           title: opt_sfixed32_value
           format: int32
+          nullable: true
         optSfixed64Value:
           type:
             - integer
             - string
           title: opt_sfixed64_value
           format: int64
+          nullable: true
         optBoolValue:
           type: boolean
           title: opt_bool_value
+          nullable: true
         optStringValue:
           type: string
           title: opt_string_value
+          nullable: true
         optBytesValue:
           type: string
           title: opt_bytes_value
           format: byte
+          nullable: true
         msgValue:
           allOf:
             - $ref: '#/components/schemas/test.v1.AllTypes'
@@ -1158,10 +1053,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/test.v1.AllTypes'
           title: opt_msg_value
+          nullable: true
         optEnumValue:
           allOf:
             - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
           title: opt_enum_value
+          nullable: true
         msgList:
           type: array
           items:

--- a/internal/converter/testdata/standard/test.proto
+++ b/internal/converter/testdata/standard/test.proto
@@ -196,4 +196,11 @@ message AllTypes {
     AllTypes msg_option = 96;
     Enum enum_option = 97;
   }
+
+  // oneof with optional fields
+  oneof oneof_optional_fields {
+    optional double double_optional_option = 98;
+    optional float float_optional_option = 99;
+    optional int32 int32_optional_option = 100;
+  }
 }

--- a/internal/converter/testdata/with_proto_annotations/output/test.openapi.json
+++ b/internal/converter/testdata/with_proto_annotations/output/test.openapi.json
@@ -221,526 +221,182 @@
       },
       "with_proto_annotations.test.v1.AllTypes": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optBoolValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optBoolValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "boolOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optBytesValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optBytesValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "bytesOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optDoubleValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optDoubleValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "doubleOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optEnumValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optEnumValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "enumOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optFixed32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optFixed32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "fixed32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optFixed64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optFixed64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "fixed64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optFloatValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optFloatValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "floatOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optInt32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optInt32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "int32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optInt64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optInt64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "int64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optMsgValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optMsgValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "msgOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSfixed32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSfixed32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sfixed32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSfixed64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSfixed64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sfixed64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSint32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSint32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sint32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optSint64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optSint64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "sint64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optStringValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optStringValue"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "stringOption"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optUint32Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optUint32Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "uint32Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "optUint64Value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "optUint64Value"
-                      ]
-                    }
-                  ]
-                }
-              }
+            "required": [
+              "uint64Option"
             ]
           },
           {
-            "anyOf": [
-              {
-                "required": [
-                  "boolOption"
-                ]
-              },
-              {
-                "required": [
-                  "bytesOption"
-                ]
-              },
-              {
-                "required": [
-                  "doubleOption"
-                ]
-              },
-              {
-                "required": [
-                  "enumOption"
-                ]
-              },
-              {
-                "required": [
-                  "fixed32Option"
-                ]
-              },
-              {
-                "required": [
-                  "fixed64Option"
-                ]
-              },
-              {
-                "required": [
-                  "floatOption"
-                ]
-              },
-              {
-                "required": [
-                  "int32Option"
-                ]
-              },
-              {
-                "required": [
-                  "int64Option"
-                ]
-              },
-              {
-                "required": [
-                  "msgOption"
-                ]
-              },
-              {
-                "required": [
-                  "sfixed32Option"
-                ]
-              },
-              {
-                "required": [
-                  "sfixed64Option"
-                ]
-              },
-              {
-                "required": [
-                  "sint32Option"
-                ]
-              },
-              {
-                "required": [
-                  "sint64Option"
-                ]
-              },
-              {
-                "required": [
-                  "stringOption"
-                ]
-              },
-              {
-                "required": [
-                  "uint32Option"
-                ]
-              },
-              {
-                "required": [
-                  "uint64Option"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "boolOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bytesOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "doubleOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "enumOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "floatOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "msgOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "stringOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint64Option"
-                      ]
-                    }
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "boolOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "bytesOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "doubleOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "enumOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "floatOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "int32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "int64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "msgOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "stringOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint64Option"
                   ]
                 }
-              }
-            ]
+              ]
+            }
           }
         ],
         "properties": {
@@ -1291,19 +947,22 @@
             "type": "number",
             "title": "opt_double_value",
             "format": "double",
-            "description": "explicit presence types (proto double)"
+            "description": "explicit presence types (proto double)",
+            "nullable": true
           },
           "optFloatValue": {
             "type": "number",
             "title": "opt_float_value",
             "format": "float",
-            "description": "(proto float)"
+            "description": "(proto float)",
+            "nullable": true
           },
           "optInt32Value": {
             "type": "integer",
             "title": "opt_int32_value",
             "format": "int32",
-            "description": "(proto int32)"
+            "description": "(proto int32)",
+            "nullable": true
           },
           "optInt64Value": {
             "type": [
@@ -1312,12 +971,14 @@
             ],
             "title": "opt_int64_value",
             "format": "int64",
-            "description": "(proto int64)"
+            "description": "(proto int64)",
+            "nullable": true
           },
           "optUint32Value": {
             "type": "integer",
             "title": "opt_uint32_value",
-            "description": "(proto uint32)"
+            "description": "(proto uint32)",
+            "nullable": true
           },
           "optUint64Value": {
             "type": [
@@ -1326,13 +987,15 @@
             ],
             "title": "opt_uint64_value",
             "format": "int64",
-            "description": "(proto uint64)"
+            "description": "(proto uint64)",
+            "nullable": true
           },
           "optSint32Value": {
             "type": "integer",
             "title": "opt_sint32_value",
             "format": "int32",
-            "description": "(proto sint32)"
+            "description": "(proto sint32)",
+            "nullable": true
           },
           "optSint64Value": {
             "type": [
@@ -1341,12 +1004,14 @@
             ],
             "title": "opt_sint64_value",
             "format": "int64",
-            "description": "(proto sint64)"
+            "description": "(proto sint64)",
+            "nullable": true
           },
           "optFixed32Value": {
             "type": "integer",
             "title": "opt_fixed32_value",
-            "description": "(proto fixed32)"
+            "description": "(proto fixed32)",
+            "nullable": true
           },
           "optFixed64Value": {
             "type": [
@@ -1355,13 +1020,15 @@
             ],
             "title": "opt_fixed64_value",
             "format": "int64",
-            "description": "(proto fixed64)"
+            "description": "(proto fixed64)",
+            "nullable": true
           },
           "optSfixed32Value": {
             "type": "integer",
             "title": "opt_sfixed32_value",
             "format": "int32",
-            "description": "(proto sfixed32)"
+            "description": "(proto sfixed32)",
+            "nullable": true
           },
           "optSfixed64Value": {
             "type": [
@@ -1370,23 +1037,27 @@
             ],
             "title": "opt_sfixed64_value",
             "format": "int64",
-            "description": "(proto sfixed64)"
+            "description": "(proto sfixed64)",
+            "nullable": true
           },
           "optBoolValue": {
             "type": "boolean",
             "title": "opt_bool_value",
-            "description": "(proto bool)"
+            "description": "(proto bool)",
+            "nullable": true
           },
           "optStringValue": {
             "type": "string",
             "title": "opt_string_value",
-            "description": "(proto string)"
+            "description": "(proto string)",
+            "nullable": true
           },
           "optBytesValue": {
             "type": "string",
             "title": "opt_bytes_value",
             "format": "byte",
-            "description": "(proto bytes)"
+            "description": "(proto bytes)",
+            "nullable": true
           },
           "msgValue": {
             "allOf": [
@@ -1413,7 +1084,8 @@
               }
             ],
             "title": "opt_msg_value",
-            "description": "(proto with_proto_annotations.test.v1.AllTypes)"
+            "description": "(proto with_proto_annotations.test.v1.AllTypes)",
+            "nullable": true
           },
           "optEnumValue": {
             "allOf": [
@@ -1422,7 +1094,8 @@
               }
             ],
             "title": "opt_enum_value",
-            "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)",
+            "nullable": true
           },
           "msgList": {
             "type": "array",

--- a/internal/converter/testdata/with_proto_annotations/output/test.openapi.yaml
+++ b/internal/converter/testdata/with_proto_annotations/output/test.openapi.yaml
@@ -541,197 +541,77 @@ components:
          The JSON representation for `Value` is JSON value.
     with_proto_annotations.test.v1.AllTypes:
       type: object
-      allOf:
-        - anyOf:
-            - required:
-                - optBoolValue
-            - not:
-                anyOf:
-                  - required:
-                      - optBoolValue
-        - anyOf:
-            - required:
-                - optBytesValue
-            - not:
-                anyOf:
-                  - required:
-                      - optBytesValue
-        - anyOf:
-            - required:
-                - optDoubleValue
-            - not:
-                anyOf:
-                  - required:
-                      - optDoubleValue
-        - anyOf:
-            - required:
-                - optEnumValue
-            - not:
-                anyOf:
-                  - required:
-                      - optEnumValue
-        - anyOf:
-            - required:
-                - optFixed32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optFixed32Value
-        - anyOf:
-            - required:
-                - optFixed64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optFixed64Value
-        - anyOf:
-            - required:
-                - optFloatValue
-            - not:
-                anyOf:
-                  - required:
-                      - optFloatValue
-        - anyOf:
-            - required:
-                - optInt32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optInt32Value
-        - anyOf:
-            - required:
-                - optInt64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optInt64Value
-        - anyOf:
-            - required:
-                - optMsgValue
-            - not:
-                anyOf:
-                  - required:
-                      - optMsgValue
-        - anyOf:
-            - required:
-                - optSfixed32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSfixed32Value
-        - anyOf:
-            - required:
-                - optSfixed64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSfixed64Value
-        - anyOf:
-            - required:
-                - optSint32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSint32Value
-        - anyOf:
-            - required:
-                - optSint64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optSint64Value
-        - anyOf:
-            - required:
-                - optStringValue
-            - not:
-                anyOf:
-                  - required:
-                      - optStringValue
-        - anyOf:
-            - required:
-                - optUint32Value
-            - not:
-                anyOf:
-                  - required:
-                      - optUint32Value
-        - anyOf:
-            - required:
-                - optUint64Value
-            - not:
-                anyOf:
-                  - required:
-                      - optUint64Value
-        - anyOf:
-            - required:
-                - boolOption
-            - required:
-                - bytesOption
-            - required:
-                - doubleOption
-            - required:
-                - enumOption
-            - required:
-                - fixed32Option
-            - required:
-                - fixed64Option
-            - required:
-                - floatOption
-            - required:
-                - int32Option
-            - required:
-                - int64Option
-            - required:
-                - msgOption
-            - required:
-                - sfixed32Option
-            - required:
-                - sfixed64Option
-            - required:
-                - sint32Option
-            - required:
-                - sint64Option
-            - required:
-                - stringOption
-            - required:
-                - uint32Option
-            - required:
-                - uint64Option
-            - not:
-                anyOf:
-                  - required:
-                      - boolOption
-                  - required:
-                      - bytesOption
-                  - required:
-                      - doubleOption
-                  - required:
-                      - enumOption
-                  - required:
-                      - fixed32Option
-                  - required:
-                      - fixed64Option
-                  - required:
-                      - floatOption
-                  - required:
-                      - int32Option
-                  - required:
-                      - int64Option
-                  - required:
-                      - msgOption
-                  - required:
-                      - sfixed32Option
-                  - required:
-                      - sfixed64Option
-                  - required:
-                      - sint32Option
-                  - required:
-                      - sint64Option
-                  - required:
-                      - stringOption
-                  - required:
-                      - uint32Option
-                  - required:
-                      - uint64Option
+      anyOf:
+        - required:
+            - boolOption
+        - required:
+            - bytesOption
+        - required:
+            - doubleOption
+        - required:
+            - enumOption
+        - required:
+            - fixed32Option
+        - required:
+            - fixed64Option
+        - required:
+            - floatOption
+        - required:
+            - int32Option
+        - required:
+            - int64Option
+        - required:
+            - msgOption
+        - required:
+            - sfixed32Option
+        - required:
+            - sfixed64Option
+        - required:
+            - sint32Option
+        - required:
+            - sint64Option
+        - required:
+            - stringOption
+        - required:
+            - uint32Option
+        - required:
+            - uint64Option
+        - not:
+            anyOf:
+              - required:
+                  - boolOption
+              - required:
+                  - bytesOption
+              - required:
+                  - doubleOption
+              - required:
+                  - enumOption
+              - required:
+                  - fixed32Option
+              - required:
+                  - fixed64Option
+              - required:
+                  - floatOption
+              - required:
+                  - int32Option
+              - required:
+                  - int64Option
+              - required:
+                  - msgOption
+              - required:
+                  - sfixed32Option
+              - required:
+                  - sfixed64Option
+              - required:
+                  - sint32Option
+              - required:
+                  - sint64Option
+              - required:
+                  - stringOption
+              - required:
+                  - uint32Option
+              - required:
+                  - uint64Option
       properties:
         doubleValue:
           type: number
@@ -1167,16 +1047,19 @@ components:
           title: opt_double_value
           format: double
           description: explicit presence types (proto double)
+          nullable: true
         optFloatValue:
           type: number
           title: opt_float_value
           format: float
           description: (proto float)
+          nullable: true
         optInt32Value:
           type: integer
           title: opt_int32_value
           format: int32
           description: (proto int32)
+          nullable: true
         optInt64Value:
           type:
             - integer
@@ -1184,10 +1067,12 @@ components:
           title: opt_int64_value
           format: int64
           description: (proto int64)
+          nullable: true
         optUint32Value:
           type: integer
           title: opt_uint32_value
           description: (proto uint32)
+          nullable: true
         optUint64Value:
           type:
             - integer
@@ -1195,11 +1080,13 @@ components:
           title: opt_uint64_value
           format: int64
           description: (proto uint64)
+          nullable: true
         optSint32Value:
           type: integer
           title: opt_sint32_value
           format: int32
           description: (proto sint32)
+          nullable: true
         optSint64Value:
           type:
             - integer
@@ -1207,10 +1094,12 @@ components:
           title: opt_sint64_value
           format: int64
           description: (proto sint64)
+          nullable: true
         optFixed32Value:
           type: integer
           title: opt_fixed32_value
           description: (proto fixed32)
+          nullable: true
         optFixed64Value:
           type:
             - integer
@@ -1218,11 +1107,13 @@ components:
           title: opt_fixed64_value
           format: int64
           description: (proto fixed64)
+          nullable: true
         optSfixed32Value:
           type: integer
           title: opt_sfixed32_value
           format: int32
           description: (proto sfixed32)
+          nullable: true
         optSfixed64Value:
           type:
             - integer
@@ -1230,19 +1121,23 @@ components:
           title: opt_sfixed64_value
           format: int64
           description: (proto sfixed64)
+          nullable: true
         optBoolValue:
           type: boolean
           title: opt_bool_value
           description: (proto bool)
+          nullable: true
         optStringValue:
           type: string
           title: opt_string_value
           description: (proto string)
+          nullable: true
         optBytesValue:
           type: string
           title: opt_bytes_value
           format: byte
           description: (proto bytes)
+          nullable: true
         msgValue:
           allOf:
             - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
@@ -1258,11 +1153,13 @@ components:
             - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
           title: opt_msg_value
           description: (proto with_proto_annotations.test.v1.AllTypes)
+          nullable: true
         optEnumValue:
           allOf:
             - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
           title: opt_enum_value
           description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+          nullable: true
         msgList:
           type: array
           items:


### PR DESCRIPTION
attempts to fix https://github.com/sudorandom/protoc-gen-connect-openapi/issues/67

In Protobuf, optional fields are internally represented using a synthetic oneof to track presence, but they should not be treated as actual oneof groups in OpenAPI.

This PR filters out optional fields from oneof processing and instead correctly marks them as nullable properties in the OpenAPI schema.