### PR TITLE
fix: bug in length handling of enums

### DIFF
--- a/internal/converter/gnostic/schema.go
+++ b/internal/converter/gnostic/schema.go
@@ -140,7 +140,7 @@ func schemaWithAnnotations(schema *base.Schema, opts *goa3.Schema) *base.Schema 
 		schema.Required = opts.Required
 	}
 	if len(opts.Enum) > 0 {
-		enums := make([]*yaml.Node, 0)
+		enums := make([]*yaml.Node, len(opts.Enum))
 		for i, enum := range opts.Enum {
 			enums[i] = enum.ToRawInfo()
 		}


### PR DESCRIPTION
`make(..., 0)` creates a zero length array, which causes a index reference issue.