### PR TITLE
Changing oneof translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ redoc-static.html
 out
 dist
 
+protoc-gen-connect-openapi
+
 coverage.out
 coverage.html

--- a/internal/converter/testdata/standard/output/envoy.openapi.json
+++ b/internal/converter/testdata/standard/output/envoy.openapi.json
@@ -410,59 +410,45 @@
       },
       "envoy.config.core.v3.Address": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "envoyInternalAddress": {
+                "title": "envoy_internal_address",
+                "description": "Specifies a user-space address handled by :ref:`internal listeners\n \u003cenvoy_v3_api_field_config.listener.v3.Listener.internal_listener\u003e`.",
+                "$ref": "#/components/schemas/envoy.config.core.v3.EnvoyInternalAddress"
+              }
+            },
+            "title": "envoy_internal_address",
             "required": [
               "envoyInternalAddress"
             ]
           },
           {
+            "properties": {
+              "pipe": {
+                "title": "pipe",
+                "$ref": "#/components/schemas/envoy.config.core.v3.Pipe"
+              }
+            },
+            "title": "pipe",
             "required": [
               "pipe"
             ]
           },
           {
+            "properties": {
+              "socketAddress": {
+                "title": "socket_address",
+                "$ref": "#/components/schemas/envoy.config.core.v3.SocketAddress"
+              }
+            },
+            "title": "socket_address",
             "required": [
               "socketAddress"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "envoyInternalAddress"
-                  ]
-                },
-                {
-                  "required": [
-                    "pipe"
-                  ]
-                },
-                {
-                  "required": [
-                    "socketAddress"
-                  ]
-                }
-              ]
-            }
           }
         ],
-        "properties": {
-          "socketAddress": {
-            "title": "socket_address",
-            "$ref": "#/components/schemas/envoy.config.core.v3.SocketAddress"
-          },
-          "pipe": {
-            "title": "pipe",
-            "$ref": "#/components/schemas/envoy.config.core.v3.Pipe"
-          },
-          "envoyInternalAddress": {
-            "title": "envoy_internal_address",
-            "description": "Specifies a user-space address handled by :ref:`internal listeners\n \u003cenvoy_v3_api_field_config.listener.v3.Listener.internal_listener\u003e`.",
-            "$ref": "#/components/schemas/envoy.config.core.v3.EnvoyInternalAddress"
-          }
-        },
         "title": "Address",
         "additionalProperties": false,
         "description": "Addresses specify either a logical or physical address and port, which are\n used to tell Envoy where to bind/listen, connect to upstream and find\n management servers."
@@ -500,30 +486,22 @@
       },
       "envoy.config.core.v3.EnvoyInternalAddress": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "serverListenerName": {
+                "type": "string",
+                "title": "server_listener_name",
+                "description": "Specifies the :ref:`name \u003cenvoy_v3_api_field_config.listener.v3.Listener.name\u003e` of the\n internal listener."
+              }
+            },
+            "title": "server_listener_name",
             "required": [
               "serverListenerName"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "serverListenerName"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
-          "serverListenerName": {
-            "type": "string",
-            "title": "server_listener_name",
-            "description": "Specifies the :ref:`name \u003cenvoy_v3_api_field_config.listener.v3.Listener.name\u003e` of the\n internal listener."
-          },
           "endpointId": {
             "type": "string",
             "title": "endpoint_id",
@@ -657,32 +635,32 @@
       },
       "envoy.config.core.v3.Node": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "userAgentBuildVersion": {
+                "title": "user_agent_build_version",
+                "description": "Structured version of the entity requesting config.",
+                "$ref": "#/components/schemas/envoy.config.core.v3.BuildVersion"
+              }
+            },
+            "title": "user_agent_build_version",
             "required": [
               "userAgentBuildVersion"
             ]
           },
           {
+            "properties": {
+              "userAgentVersion": {
+                "type": "string",
+                "title": "user_agent_version",
+                "description": "Free-form string that identifies the version of the entity requesting config.\n E.g. \"1.12.2\" or \"abcd1234\", or \"SpecialEnvoyBuild\""
+              }
+            },
+            "title": "user_agent_version",
             "required": [
               "userAgentVersion"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "userAgentBuildVersion"
-                  ]
-                },
-                {
-                  "required": [
-                    "userAgentVersion"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -719,16 +697,6 @@
             "type": "string",
             "title": "user_agent_name",
             "description": "Free-form string that identifies the entity requesting config.\n E.g. \"envoy\" or \"grpc\""
-          },
-          "userAgentVersion": {
-            "type": "string",
-            "title": "user_agent_version",
-            "description": "Free-form string that identifies the version of the entity requesting config.\n E.g. \"1.12.2\" or \"abcd1234\", or \"SpecialEnvoyBuild\""
-          },
-          "userAgentBuildVersion": {
-            "title": "user_agent_build_version",
-            "description": "Structured version of the entity requesting config.",
-            "$ref": "#/components/schemas/envoy.config.core.v3.BuildVersion"
           },
           "extensions": {
             "type": "array",
@@ -794,32 +762,31 @@
       },
       "envoy.config.core.v3.SocketAddress": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "namedPort": {
+                "type": "string",
+                "title": "named_port",
+                "description": "This is only valid if :ref:`resolver_name\n \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e` is specified below and the\n named resolver is capable of named port resolution."
+              }
+            },
+            "title": "named_port",
             "required": [
               "namedPort"
             ]
           },
           {
+            "properties": {
+              "portValue": {
+                "type": "integer",
+                "title": "port_value"
+              }
+            },
+            "title": "port_value",
             "required": [
               "portValue"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "namedPort"
-                  ]
-                },
-                {
-                  "required": [
-                    "portValue"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -831,15 +798,6 @@
             "type": "string",
             "title": "address",
             "description": "The address for this socket. :ref:`Listeners \u003cconfig_listeners\u003e` will bind\n to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``\n to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:\n It is possible to distinguish a Listener address via the prefix/suffix matching\n in :ref:`FilterChainMatch \u003cenvoy_v3_api_msg_config.listener.v3.FilterChainMatch\u003e`.] When used\n within an upstream :ref:`BindConfig \u003cenvoy_v3_api_msg_config.core.v3.BindConfig\u003e`, the address\n controls the source address of outbound connections. For :ref:`clusters\n \u003cenvoy_v3_api_msg_config.cluster.v3.Cluster\u003e`, the cluster type determines whether the\n address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS\n (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized\n via :ref:`resolver_name \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e`."
-          },
-          "portValue": {
-            "type": "integer",
-            "title": "port_value"
-          },
-          "namedPort": {
-            "type": "string",
-            "title": "named_port",
-            "description": "This is only valid if :ref:`resolver_name\n \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e` is specified below and the\n named resolver is capable of named port resolution."
           },
           "resolverName": {
             "type": "string",
@@ -1084,76 +1042,60 @@
       },
       "envoy.service.discovery.v3.DynamicParameterConstraints": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "andConstraints": {
+                "title": "and_constraints",
+                "description": "A list of constraints that must all match.",
+                "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList"
+              }
+            },
+            "title": "and_constraints",
             "required": [
               "andConstraints"
             ]
           },
           {
+            "properties": {
+              "constraint": {
+                "title": "constraint",
+                "description": "A single constraint to evaluate.",
+                "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint"
+              }
+            },
+            "title": "constraint",
             "required": [
               "constraint"
             ]
           },
           {
+            "properties": {
+              "notConstraints": {
+                "title": "not_constraints",
+                "description": "The inverse (NOT) of a set of constraints.",
+                "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints"
+              }
+            },
+            "title": "not_constraints",
             "required": [
               "notConstraints"
             ]
           },
           {
+            "properties": {
+              "orConstraints": {
+                "title": "or_constraints",
+                "description": "A list of constraints that match if any one constraint in the list\n matches.",
+                "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList"
+              }
+            },
+            "title": "or_constraints",
             "required": [
               "orConstraints"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "andConstraints"
-                  ]
-                },
-                {
-                  "required": [
-                    "constraint"
-                  ]
-                },
-                {
-                  "required": [
-                    "notConstraints"
-                  ]
-                },
-                {
-                  "required": [
-                    "orConstraints"
-                  ]
-                }
-              ]
-            }
           }
         ],
-        "properties": {
-          "constraint": {
-            "title": "constraint",
-            "description": "A single constraint to evaluate.",
-            "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint"
-          },
-          "orConstraints": {
-            "title": "or_constraints",
-            "description": "A list of constraints that match if any one constraint in the list\n matches.",
-            "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList"
-          },
-          "andConstraints": {
-            "title": "and_constraints",
-            "description": "A list of constraints that must all match.",
-            "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList"
-          },
-          "notConstraints": {
-            "title": "not_constraints",
-            "description": "The inverse (NOT) of a set of constraints.",
-            "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints"
-          }
-        },
         "title": "DynamicParameterConstraints",
         "additionalProperties": false,
         "description": "A set of dynamic parameter constraints associated with a variant of an individual xDS resource.\n These constraints determine whether the resource matches a subscription based on the set of\n dynamic parameters in the subscription, as specified in the\n :ref:`ResourceLocator.dynamic_parameters\u003cenvoy_v3_api_field_service.discovery.v3.ResourceLocator.dynamic_parameters\u003e`\n field. This allows xDS implementations (clients, servers, and caching proxies) to determine\n which variant of a resource is appropriate for a given client."
@@ -1174,32 +1116,32 @@
       },
       "envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "exists": {
+                "title": "exists",
+                "description": "Key is present (matches any value except for the key being absent).\n This allows setting a default constraint for clients that do\n not send a key at all, while there may be other clients that need\n special configuration based on that key.",
+                "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists"
+              }
+            },
+            "title": "exists",
             "required": [
               "exists"
             ]
           },
           {
+            "properties": {
+              "value": {
+                "type": "string",
+                "title": "value",
+                "description": "Matches this exact value."
+              }
+            },
+            "title": "value",
             "required": [
               "value"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "exists"
-                  ]
-                },
-                {
-                  "required": [
-                    "value"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -1207,16 +1149,6 @@
             "type": "string",
             "title": "key",
             "description": "The key to match against."
-          },
-          "value": {
-            "type": "string",
-            "title": "value",
-            "description": "Matches this exact value."
-          },
-          "exists": {
-            "title": "exists",
-            "description": "Key is present (matches any value except for the key being absent).\n This allows setting a default constraint for clients that do\n not send a key at all, while there may be other clients that need\n special configuration based on that key.",
-            "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists"
           }
         },
         "title": "SingleConstraint",

--- a/internal/converter/testdata/standard/output/envoy.openapi.yaml
+++ b/internal/converter/testdata/standard/output/envoy.openapi.yaml
@@ -254,34 +254,31 @@ components:
          The JSON representation for `NullValue` is JSON `null`.
     envoy.config.core.v3.Address:
       type: object
-      anyOf:
-        - required:
-            - envoyInternalAddress
-        - required:
-            - pipe
-        - required:
-            - socketAddress
-        - not:
-            anyOf:
-              - required:
-                  - envoyInternalAddress
-              - required:
-                  - pipe
-              - required:
-                  - socketAddress
-      properties:
-        socketAddress:
-          title: socket_address
-          $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress'
-        pipe:
-          title: pipe
-          $ref: '#/components/schemas/envoy.config.core.v3.Pipe'
-        envoyInternalAddress:
+      oneOf:
+        - properties:
+            envoyInternalAddress:
+              title: envoy_internal_address
+              description: |-
+                Specifies a user-space address handled by :ref:`internal listeners
+                 <envoy_v3_api_field_config.listener.v3.Listener.internal_listener>`.
+              $ref: '#/components/schemas/envoy.config.core.v3.EnvoyInternalAddress'
           title: envoy_internal_address
-          description: |-
-            Specifies a user-space address handled by :ref:`internal listeners
-             <envoy_v3_api_field_config.listener.v3.Listener.internal_listener>`.
-          $ref: '#/components/schemas/envoy.config.core.v3.EnvoyInternalAddress'
+          required:
+            - envoyInternalAddress
+        - properties:
+            pipe:
+              title: pipe
+              $ref: '#/components/schemas/envoy.config.core.v3.Pipe'
+          title: pipe
+          required:
+            - pipe
+        - properties:
+            socketAddress:
+              title: socket_address
+              $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress'
+          title: socket_address
+          required:
+            - socketAddress
       title: Address
       additionalProperties: false
       description: |-
@@ -321,20 +318,18 @@ components:
       description: Identifies a specific ControlPlane instance that Envoy is connected to.
     envoy.config.core.v3.EnvoyInternalAddress:
       type: object
-      anyOf:
-        - required:
-            - serverListenerName
-        - not:
-            anyOf:
-              - required:
-                  - serverListenerName
-      properties:
-        serverListenerName:
-          type: string
+      oneOf:
+        - properties:
+            serverListenerName:
+              type: string
+              title: server_listener_name
+              description: |-
+                Specifies the :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the
+                 internal listener.
           title: server_listener_name
-          description: |-
-            Specifies the :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the
-             internal listener.
+          required:
+            - serverListenerName
+      properties:
         endpointId:
           type: string
           title: endpoint_id
@@ -502,17 +497,25 @@ components:
       additionalProperties: false
     envoy.config.core.v3.Node:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            userAgentBuildVersion:
+              title: user_agent_build_version
+              description: Structured version of the entity requesting config.
+              $ref: '#/components/schemas/envoy.config.core.v3.BuildVersion'
+          title: user_agent_build_version
+          required:
             - userAgentBuildVersion
-        - required:
+        - properties:
+            userAgentVersion:
+              type: string
+              title: user_agent_version
+              description: |-
+                Free-form string that identifies the version of the entity requesting config.
+                 E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
+          title: user_agent_version
+          required:
             - userAgentVersion
-        - not:
-            anyOf:
-              - required:
-                  - userAgentBuildVersion
-              - required:
-                  - userAgentVersion
       properties:
         id:
           type: string
@@ -568,16 +571,6 @@ components:
           description: |-
             Free-form string that identifies the entity requesting config.
              E.g. "envoy" or "grpc"
-        userAgentVersion:
-          type: string
-          title: user_agent_version
-          description: |-
-            Free-form string that identifies the version of the entity requesting config.
-             E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
-        userAgentBuildVersion:
-          title: user_agent_build_version
-          description: Structured version of the entity requesting config.
-          $ref: '#/components/schemas/envoy.config.core.v3.BuildVersion'
         extensions:
           type: array
           items:
@@ -643,17 +636,25 @@ components:
       additionalProperties: false
     envoy.config.core.v3.SocketAddress:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            namedPort:
+              type: string
+              title: named_port
+              description: |-
+                This is only valid if :ref:`resolver_name
+                 <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
+                 named resolver is capable of named port resolution.
+          title: named_port
+          required:
             - namedPort
-        - required:
+        - properties:
+            portValue:
+              type: integer
+              title: port_value
+          title: port_value
+          required:
             - portValue
-        - not:
-            anyOf:
-              - required:
-                  - namedPort
-              - required:
-                  - portValue
       properties:
         protocol:
           title: protocol
@@ -673,16 +674,6 @@ components:
              address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS
              (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized
              via :ref:`resolver_name <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`.
-        portValue:
-          type: integer
-          title: port_value
-        namedPort:
-          type: string
-          title: named_port
-          description: |-
-            This is only valid if :ref:`resolver_name
-             <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
-             named resolver is capable of named port resolution.
         resolverName:
           type: string
           title: resolver_name
@@ -1035,44 +1026,41 @@ components:
       description: '[#next-free-field: 7]'
     envoy.service.discovery.v3.DynamicParameterConstraints:
       type: object
-      anyOf:
-        - required:
-            - andConstraints
-        - required:
-            - constraint
-        - required:
-            - notConstraints
-        - required:
-            - orConstraints
-        - not:
-            anyOf:
-              - required:
-                  - andConstraints
-              - required:
-                  - constraint
-              - required:
-                  - notConstraints
-              - required:
-                  - orConstraints
-      properties:
-        constraint:
-          title: constraint
-          description: A single constraint to evaluate.
-          $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint'
-        orConstraints:
-          title: or_constraints
-          description: |-
-            A list of constraints that match if any one constraint in the list
-             matches.
-          $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList'
-        andConstraints:
+      oneOf:
+        - properties:
+            andConstraints:
+              title: and_constraints
+              description: A list of constraints that must all match.
+              $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList'
           title: and_constraints
-          description: A list of constraints that must all match.
-          $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList'
-        notConstraints:
+          required:
+            - andConstraints
+        - properties:
+            constraint:
+              title: constraint
+              description: A single constraint to evaluate.
+              $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint'
+          title: constraint
+          required:
+            - constraint
+        - properties:
+            notConstraints:
+              title: not_constraints
+              description: The inverse (NOT) of a set of constraints.
+              $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints'
           title: not_constraints
-          description: The inverse (NOT) of a set of constraints.
-          $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints'
+          required:
+            - notConstraints
+        - properties:
+            orConstraints:
+              title: or_constraints
+              description: |-
+                A list of constraints that match if any one constraint in the list
+                 matches.
+              $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList'
+          title: or_constraints
+          required:
+            - orConstraints
       title: DynamicParameterConstraints
       additionalProperties: false
       description: |-
@@ -1094,34 +1082,32 @@ components:
       additionalProperties: false
     envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            exists:
+              title: exists
+              description: |-
+                Key is present (matches any value except for the key being absent).
+                 This allows setting a default constraint for clients that do
+                 not send a key at all, while there may be other clients that need
+                 special configuration based on that key.
+              $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists'
+          title: exists
+          required:
             - exists
-        - required:
+        - properties:
+            value:
+              type: string
+              title: value
+              description: Matches this exact value.
+          title: value
+          required:
             - value
-        - not:
-            anyOf:
-              - required:
-                  - exists
-              - required:
-                  - value
       properties:
         key:
           type: string
           title: key
           description: The key to match against.
-        value:
-          type: string
-          title: value
-          description: Matches this exact value.
-        exists:
-          title: exists
-          description: |-
-            Key is present (matches any value except for the key being absent).
-             This allows setting a default constraint for clients that do
-             not send a key at all, while there may be other clients that need
-             special configuration based on that key.
-          $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists'
       title: SingleConstraint
       additionalProperties: false
       description: A single constraint for a given key.

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.json
@@ -226,45 +226,33 @@
       },
       "protovalidate.CELMessage": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "a": {
+                "type": "string",
+                "title": "a",
+                "minLength": 1
+              }
+            },
+            "title": "a",
             "required": [
               "a"
             ]
           },
           {
+            "properties": {
+              "b": {
+                "type": "string",
+                "title": "b"
+              }
+            },
+            "title": "b",
             "required": [
               "b"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "a"
-                  ]
-                },
-                {
-                  "required": [
-                    "b"
-                  ]
-                }
-              ]
-            }
           }
         ],
-        "properties": {
-          "a": {
-            "type": "string",
-            "title": "a",
-            "minLength": 1
-          },
-          "b": {
-            "type": "string",
-            "title": "b"
-          }
-        },
         "title": "CELMessage",
         "additionalProperties": false
       },
@@ -1767,45 +1755,33 @@
       },
       "protovalidate.OneOfMessage": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "a": {
+                "type": "string",
+                "title": "a",
+                "minLength": 1
+              }
+            },
+            "title": "a",
             "required": [
               "a"
             ]
           },
           {
+            "properties": {
+              "b": {
+                "type": "string",
+                "title": "b"
+              }
+            },
+            "title": "b",
             "required": [
               "b"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "a"
-                  ]
-                },
-                {
-                  "required": [
-                    "b"
-                  ]
-                }
-              ]
-            }
           }
         ],
-        "properties": {
-          "a": {
-            "type": "string",
-            "title": "a",
-            "minLength": 1
-          },
-          "b": {
-            "type": "string",
-            "title": "b"
-          }
-        },
         "title": "OneOfMessage",
         "additionalProperties": false
       },

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
@@ -301,25 +301,22 @@ components:
          ) to obtain a formatter capable of generating timestamps in this format.
     protovalidate.CELMessage:
       type: object
-      anyOf:
-        - required:
-            - a
-        - required:
-            - b
-        - not:
-            anyOf:
-              - required:
-                  - a
-              - required:
-                  - b
-      properties:
-        a:
-          type: string
+      oneOf:
+        - properties:
+            a:
+              type: string
+              title: a
+              minLength: 1
           title: a
-          minLength: 1
-        b:
-          type: string
+          required:
+            - a
+        - properties:
+            b:
+              type: string
+              title: b
           title: b
+          required:
+            - b
       title: CELMessage
       additionalProperties: false
     protovalidate.DisabledMessage:
@@ -1494,25 +1491,22 @@ components:
       additionalProperties: false
     protovalidate.OneOfMessage:
       type: object
-      anyOf:
-        - required:
-            - a
-        - required:
-            - b
-        - not:
-            anyOf:
-              - required:
-                  - a
-              - required:
-                  - b
-      properties:
-        a:
-          type: string
+      oneOf:
+        - properties:
+            a:
+              type: string
+              title: a
+              minLength: 1
           title: a
-          minLength: 1
-        b:
-          type: string
+          required:
+            - a
+        - properties:
+            b:
+              type: string
+              title: b
           title: b
+          required:
+            - b
       title: OneOfMessage
       additionalProperties: false
     connect-protocol-version:

--- a/internal/converter/testdata/standard/output/protovalidate.strings.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.strings.openapi.json
@@ -289,34 +289,24 @@
       },
       "buf.validate.conformance.cases.StringInOneof": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "bar": {
+                "type": "string",
+                "title": "bar",
+                "enum": [
+                  "a",
+                  "b"
+                ]
+              }
+            },
+            "title": "bar",
             "required": [
               "bar"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "bar"
-                  ]
-                }
-              ]
-            }
           }
         ],
-        "properties": {
-          "bar": {
-            "type": "string",
-            "title": "bar",
-            "enum": [
-              "a",
-              "b"
-            ]
-          }
-        },
         "title": "StringInOneof",
         "additionalProperties": false
       },

--- a/internal/converter/testdata/standard/output/protovalidate.strings.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.strings.openapi.yaml
@@ -218,20 +218,17 @@ components:
       additionalProperties: false
     buf.validate.conformance.cases.StringInOneof:
       type: object
-      anyOf:
-        - required:
-            - bar
-        - not:
-            anyOf:
-              - required:
-                  - bar
-      properties:
-        bar:
-          type: string
+      oneOf:
+        - properties:
+            bar:
+              type: string
+              title: bar
+              enum:
+                - a
+                - b
           title: bar
-          enum:
-            - a
-            - b
+          required:
+            - bar
       title: StringInOneof
       additionalProperties: false
     buf.validate.conformance.cases.StringLen:

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.json
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.json
@@ -952,172 +952,144 @@
       },
       "tensorflow.AttrValue": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "b": {
+                "type": "boolean",
+                "title": "b",
+                "description": "\"bool\""
+              }
+            },
+            "title": "b",
             "required": [
               "b"
             ]
           },
           {
+            "properties": {
+              "f": {
+                "type": "number",
+                "title": "f",
+                "format": "float",
+                "description": "\"float\""
+              }
+            },
+            "title": "f",
             "required": [
               "f"
             ]
           },
           {
+            "properties": {
+              "func": {
+                "title": "func",
+                "description": "\"func\" represents a function. func.name is a function's name or\n a primitive op's name. func.attr.first is the name of an attr\n defined for that function. func.attr.second is the value for\n that attr in the instantiation.",
+                "$ref": "#/components/schemas/tensorflow.NameAttrList"
+              }
+            },
+            "title": "func",
             "required": [
               "func"
             ]
           },
           {
+            "properties": {
+              "i": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "i",
+                "format": "int64",
+                "description": "\"int\""
+              }
+            },
+            "title": "i",
             "required": [
               "i"
             ]
           },
           {
+            "properties": {
+              "list": {
+                "title": "list",
+                "description": "any \"list(...)\"",
+                "$ref": "#/components/schemas/tensorflow.AttrValue.ListValue"
+              }
+            },
+            "title": "list",
             "required": [
               "list"
             ]
           },
           {
+            "properties": {
+              "placeholder": {
+                "type": "string",
+                "title": "placeholder",
+                "description": "This is a placeholder only used in nodes defined inside a\n function.  It indicates the attr value will be supplied when\n the function is instantiated.  For example, let us suppose a\n node \"N\" in function \"FN\". \"N\" has an attr \"A\" with value\n placeholder = \"foo\". When FN is instantiated with attr \"foo\"\n set to \"bar\", the instantiated node N's attr A will have been\n given the value \"bar\"."
+              }
+            },
+            "title": "placeholder",
             "required": [
               "placeholder"
             ]
           },
           {
+            "properties": {
+              "s": {
+                "type": "string",
+                "title": "s",
+                "format": "byte",
+                "description": "\"string\""
+              }
+            },
+            "title": "s",
             "required": [
               "s"
             ]
           },
           {
+            "properties": {
+              "shape": {
+                "title": "shape",
+                "description": "\"shape\"",
+                "$ref": "#/components/schemas/tensorflow.TensorShapeProto"
+              }
+            },
+            "title": "shape",
             "required": [
               "shape"
             ]
           },
           {
+            "properties": {
+              "tensor": {
+                "title": "tensor",
+                "description": "\"tensor\"",
+                "$ref": "#/components/schemas/tensorflow.TensorProto"
+              }
+            },
+            "title": "tensor",
             "required": [
               "tensor"
             ]
           },
           {
+            "properties": {
+              "type": {
+                "title": "type",
+                "description": "\"type\"",
+                "$ref": "#/components/schemas/tensorflow.DataType"
+              }
+            },
+            "title": "type",
             "required": [
               "type"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "b"
-                  ]
-                },
-                {
-                  "required": [
-                    "f"
-                  ]
-                },
-                {
-                  "required": [
-                    "func"
-                  ]
-                },
-                {
-                  "required": [
-                    "i"
-                  ]
-                },
-                {
-                  "required": [
-                    "list"
-                  ]
-                },
-                {
-                  "required": [
-                    "placeholder"
-                  ]
-                },
-                {
-                  "required": [
-                    "s"
-                  ]
-                },
-                {
-                  "required": [
-                    "shape"
-                  ]
-                },
-                {
-                  "required": [
-                    "tensor"
-                  ]
-                },
-                {
-                  "required": [
-                    "type"
-                  ]
-                }
-              ]
-            }
           }
         ],
-        "properties": {
-          "s": {
-            "type": "string",
-            "title": "s",
-            "format": "byte",
-            "description": "\"string\""
-          },
-          "i": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "i",
-            "format": "int64",
-            "description": "\"int\""
-          },
-          "f": {
-            "type": "number",
-            "title": "f",
-            "format": "float",
-            "description": "\"float\""
-          },
-          "b": {
-            "type": "boolean",
-            "title": "b",
-            "description": "\"bool\""
-          },
-          "type": {
-            "title": "type",
-            "description": "\"type\"",
-            "$ref": "#/components/schemas/tensorflow.DataType"
-          },
-          "shape": {
-            "title": "shape",
-            "description": "\"shape\"",
-            "$ref": "#/components/schemas/tensorflow.TensorShapeProto"
-          },
-          "tensor": {
-            "title": "tensor",
-            "description": "\"tensor\"",
-            "$ref": "#/components/schemas/tensorflow.TensorProto"
-          },
-          "list": {
-            "title": "list",
-            "description": "any \"list(...)\"",
-            "$ref": "#/components/schemas/tensorflow.AttrValue.ListValue"
-          },
-          "func": {
-            "title": "func",
-            "description": "\"func\" represents a function. func.name is a function's name or\n a primitive op's name. func.attr.first is the name of an attr\n defined for that function. func.attr.second is the value for\n that attr in the instantiation.",
-            "$ref": "#/components/schemas/tensorflow.NameAttrList"
-          },
-          "placeholder": {
-            "type": "string",
-            "title": "placeholder",
-            "description": "This is a placeholder only used in nodes defined inside a\n function.  It indicates the attr value will be supplied when\n the function is instantiated.  For example, let us suppose a\n node \"N\" in function \"FN\". \"N\" has an attr \"A\" with value\n placeholder = \"foo\". When FN is instantiated with attr \"foo\"\n set to \"bar\", the instantiated node N's attr A will have been\n given the value \"bar\"."
-          }
-        },
         "title": "AttrValue",
         "additionalProperties": false,
         "description": "Protocol buffer representing the value for an attr used to configure an Op.\n Comment indicates the corresponding attr type.  Only the field matching the\n attr type may be filled."
@@ -2179,32 +2151,35 @@
       },
       "tensorflow.FullTypeDef": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "i": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "i",
+                "format": "int64",
+                "description": "TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc."
+              }
+            },
+            "title": "i",
             "required": [
               "i"
             ]
           },
           {
+            "properties": {
+              "s": {
+                "type": "string",
+                "title": "s"
+              }
+            },
+            "title": "s",
             "required": [
               "s"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "i"
-                  ]
-                },
-                {
-                  "required": [
-                    "s"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -2219,19 +2194,6 @@
               "$ref": "#/components/schemas/tensorflow.FullTypeDef"
             },
             "title": "args"
-          },
-          "s": {
-            "type": "string",
-            "title": "s"
-          },
-          "i": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "i",
-            "format": "int64",
-            "description": "TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc."
           }
         },
         "title": "FullTypeDef",

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
@@ -692,106 +692,103 @@ components:
       additionalProperties: false
     tensorflow.AttrValue:
       type: object
-      anyOf:
-        - required:
-            - b
-        - required:
-            - f
-        - required:
-            - func
-        - required:
-            - i
-        - required:
-            - list
-        - required:
-            - placeholder
-        - required:
-            - s
-        - required:
-            - shape
-        - required:
-            - tensor
-        - required:
-            - type
-        - not:
-            anyOf:
-              - required:
-                  - b
-              - required:
-                  - f
-              - required:
-                  - func
-              - required:
-                  - i
-              - required:
-                  - list
-              - required:
-                  - placeholder
-              - required:
-                  - s
-              - required:
-                  - shape
-              - required:
-                  - tensor
-              - required:
-                  - type
-      properties:
-        s:
-          type: string
-          title: s
-          format: byte
-          description: '"string"'
-        i:
-          type:
-            - integer
-            - string
-          title: i
-          format: int64
-          description: '"int"'
-        f:
-          type: number
-          title: f
-          format: float
-          description: '"float"'
-        b:
-          type: boolean
+      oneOf:
+        - properties:
+            b:
+              type: boolean
+              title: b
+              description: '"bool"'
           title: b
-          description: '"bool"'
-        type:
-          title: type
-          description: '"type"'
-          $ref: '#/components/schemas/tensorflow.DataType'
-        shape:
-          title: shape
-          description: '"shape"'
-          $ref: '#/components/schemas/tensorflow.TensorShapeProto'
-        tensor:
-          title: tensor
-          description: '"tensor"'
-          $ref: '#/components/schemas/tensorflow.TensorProto'
-        list:
-          title: list
-          description: any "list(...)"
-          $ref: '#/components/schemas/tensorflow.AttrValue.ListValue'
-        func:
+          required:
+            - b
+        - properties:
+            f:
+              type: number
+              title: f
+              format: float
+              description: '"float"'
+          title: f
+          required:
+            - f
+        - properties:
+            func:
+              title: func
+              description: |-
+                "func" represents a function. func.name is a function's name or
+                 a primitive op's name. func.attr.first is the name of an attr
+                 defined for that function. func.attr.second is the value for
+                 that attr in the instantiation.
+              $ref: '#/components/schemas/tensorflow.NameAttrList'
           title: func
-          description: |-
-            "func" represents a function. func.name is a function's name or
-             a primitive op's name. func.attr.first is the name of an attr
-             defined for that function. func.attr.second is the value for
-             that attr in the instantiation.
-          $ref: '#/components/schemas/tensorflow.NameAttrList'
-        placeholder:
-          type: string
+          required:
+            - func
+        - properties:
+            i:
+              type:
+                - integer
+                - string
+              title: i
+              format: int64
+              description: '"int"'
+          title: i
+          required:
+            - i
+        - properties:
+            list:
+              title: list
+              description: any "list(...)"
+              $ref: '#/components/schemas/tensorflow.AttrValue.ListValue'
+          title: list
+          required:
+            - list
+        - properties:
+            placeholder:
+              type: string
+              title: placeholder
+              description: |-
+                This is a placeholder only used in nodes defined inside a
+                 function.  It indicates the attr value will be supplied when
+                 the function is instantiated.  For example, let us suppose a
+                 node "N" in function "FN". "N" has an attr "A" with value
+                 placeholder = "foo". When FN is instantiated with attr "foo"
+                 set to "bar", the instantiated node N's attr A will have been
+                 given the value "bar".
           title: placeholder
-          description: |-
-            This is a placeholder only used in nodes defined inside a
-             function.  It indicates the attr value will be supplied when
-             the function is instantiated.  For example, let us suppose a
-             node "N" in function "FN". "N" has an attr "A" with value
-             placeholder = "foo". When FN is instantiated with attr "foo"
-             set to "bar", the instantiated node N's attr A will have been
-             given the value "bar".
+          required:
+            - placeholder
+        - properties:
+            s:
+              type: string
+              title: s
+              format: byte
+              description: '"string"'
+          title: s
+          required:
+            - s
+        - properties:
+            shape:
+              title: shape
+              description: '"shape"'
+              $ref: '#/components/schemas/tensorflow.TensorShapeProto'
+          title: shape
+          required:
+            - shape
+        - properties:
+            tensor:
+              title: tensor
+              description: '"tensor"'
+              $ref: '#/components/schemas/tensorflow.TensorProto'
+          title: tensor
+          required:
+            - tensor
+        - properties:
+            type:
+              title: type
+              description: '"type"'
+              $ref: '#/components/schemas/tensorflow.DataType'
+          title: type
+          required:
+            - type
       title: AttrValue
       additionalProperties: false
       description: |-
@@ -1964,17 +1961,25 @@ components:
       description: 'TODO(mrry): Return something about the operation?'
     tensorflow.FullTypeDef:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            i:
+              type:
+                - integer
+                - string
+              title: i
+              format: int64
+              description: 'TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc.'
+          title: i
+          required:
             - i
-        - required:
+        - properties:
+            s:
+              type: string
+              title: s
+          title: s
+          required:
             - s
-        - not:
-            anyOf:
-              - required:
-                  - i
-              - required:
-                  - s
       properties:
         typeId:
           title: type_id
@@ -1988,16 +1993,6 @@ components:
           items:
             $ref: '#/components/schemas/tensorflow.FullTypeDef'
           title: args
-        s:
-          type: string
-          title: s
-        i:
-          type:
-            - integer
-            - string
-          title: i
-          format: int64
-          description: 'TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc.'
       title: FullTypeDef
       additionalProperties: false
       description: |-

--- a/internal/converter/testdata/standard/output/test.openapi.json
+++ b/internal/converter/testdata/standard/output/test.openapi.json
@@ -200,182 +200,237 @@
       },
       "test.v1.AllTypes": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "boolOption": {
+                "type": "boolean",
+                "title": "bool_option"
+              }
+            },
+            "title": "bool_option",
             "required": [
               "boolOption"
             ]
           },
           {
+            "properties": {
+              "bytesOption": {
+                "type": "string",
+                "title": "bytes_option",
+                "format": "byte"
+              }
+            },
+            "title": "bytes_option",
             "required": [
               "bytesOption"
             ]
           },
           {
+            "properties": {
+              "doubleOption": {
+                "type": "number",
+                "title": "double_option",
+                "format": "double",
+                "deprecated": true
+              }
+            },
+            "title": "double_option",
             "required": [
               "doubleOption"
             ]
           },
           {
+            "properties": {
+              "enumOption": {
+                "title": "enum_option",
+                "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
+              }
+            },
+            "title": "enum_option",
             "required": [
               "enumOption"
             ]
           },
           {
+            "properties": {
+              "fixed32Option": {
+                "type": "integer",
+                "title": "fixed32_option"
+              }
+            },
+            "title": "fixed32_option",
             "required": [
               "fixed32Option"
             ]
           },
           {
+            "properties": {
+              "fixed64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "fixed64_option",
+                "format": "int64"
+              }
+            },
+            "title": "fixed64_option",
             "required": [
               "fixed64Option"
             ]
           },
           {
+            "properties": {
+              "floatOption": {
+                "type": "number",
+                "title": "float_option",
+                "format": "float"
+              }
+            },
+            "title": "float_option",
             "required": [
               "floatOption"
             ]
           },
           {
+            "properties": {
+              "int32Option": {
+                "type": "integer",
+                "title": "int32_option",
+                "format": "int32"
+              }
+            },
+            "title": "int32_option",
             "required": [
               "int32Option"
             ]
           },
           {
+            "properties": {
+              "int64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "int64_option",
+                "format": "int64"
+              }
+            },
+            "title": "int64_option",
             "required": [
               "int64Option"
             ]
           },
           {
+            "properties": {
+              "msgOption": {
+                "title": "msg_option",
+                "$ref": "#/components/schemas/test.v1.AllTypes"
+              }
+            },
+            "title": "msg_option",
             "required": [
               "msgOption"
             ]
           },
           {
+            "properties": {
+              "sfixed32Option": {
+                "type": "integer",
+                "title": "sfixed32_option",
+                "format": "int32"
+              }
+            },
+            "title": "sfixed32_option",
             "required": [
               "sfixed32Option"
             ]
           },
           {
+            "properties": {
+              "sfixed64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "sfixed64_option",
+                "format": "int64"
+              }
+            },
+            "title": "sfixed64_option",
             "required": [
               "sfixed64Option"
             ]
           },
           {
+            "properties": {
+              "sint32Option": {
+                "type": "integer",
+                "title": "sint32_option",
+                "format": "int32"
+              }
+            },
+            "title": "sint32_option",
             "required": [
               "sint32Option"
             ]
           },
           {
+            "properties": {
+              "sint64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "sint64_option",
+                "format": "int64"
+              }
+            },
+            "title": "sint64_option",
             "required": [
               "sint64Option"
             ]
           },
           {
+            "properties": {
+              "stringOption": {
+                "type": "string",
+                "title": "string_option"
+              }
+            },
+            "title": "string_option",
             "required": [
               "stringOption"
             ]
           },
           {
+            "properties": {
+              "uint32Option": {
+                "type": "integer",
+                "title": "uint32_option"
+              }
+            },
+            "title": "uint32_option",
             "required": [
               "uint32Option"
             ]
           },
           {
+            "properties": {
+              "uint64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "uint64_option",
+                "format": "int64"
+              }
+            },
+            "title": "uint64_option",
             "required": [
               "uint64Option"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "boolOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "bytesOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "doubleOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "enumOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "fixed32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "fixed64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "floatOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "int32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "int64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "msgOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "sfixed32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "sfixed64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "sint32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "sint64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "stringOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "uint32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "uint64Option"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -994,101 +1049,6 @@
               "title": "value",
               "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
             }
-          },
-          "doubleOption": {
-            "type": "number",
-            "title": "double_option",
-            "format": "double",
-            "deprecated": true
-          },
-          "floatOption": {
-            "type": "number",
-            "title": "float_option",
-            "format": "float"
-          },
-          "int32Option": {
-            "type": "integer",
-            "title": "int32_option",
-            "format": "int32"
-          },
-          "int64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "int64_option",
-            "format": "int64"
-          },
-          "uint32Option": {
-            "type": "integer",
-            "title": "uint32_option"
-          },
-          "uint64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "uint64_option",
-            "format": "int64"
-          },
-          "sint32Option": {
-            "type": "integer",
-            "title": "sint32_option",
-            "format": "int32"
-          },
-          "sint64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "sint64_option",
-            "format": "int64"
-          },
-          "fixed32Option": {
-            "type": "integer",
-            "title": "fixed32_option"
-          },
-          "fixed64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "fixed64_option",
-            "format": "int64"
-          },
-          "sfixed32Option": {
-            "type": "integer",
-            "title": "sfixed32_option",
-            "format": "int32"
-          },
-          "sfixed64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "sfixed64_option",
-            "format": "int64"
-          },
-          "boolOption": {
-            "type": "boolean",
-            "title": "bool_option"
-          },
-          "stringOption": {
-            "type": "string",
-            "title": "string_option"
-          },
-          "bytesOption": {
-            "type": "string",
-            "title": "bytes_option",
-            "format": "byte"
-          },
-          "msgOption": {
-            "title": "msg_option",
-            "$ref": "#/components/schemas/test.v1.AllTypes"
-          },
-          "enumOption": {
-            "title": "enum_option",
-            "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
           }
         },
         "title": "AllTypes",
@@ -1580,42 +1540,43 @@
       },
       "test.v1.ParameterValues": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "oneofDoubleValue": {
+                "type": "number",
+                "title": "oneof_double_value",
+                "format": "double"
+              }
+            },
+            "title": "oneof_double_value",
             "required": [
               "oneofDoubleValue"
             ]
           },
           {
+            "properties": {
+              "oneofDoubleValueWrapper": {
+                "title": "oneof_double_value_wrapper",
+                "$ref": "#/components/schemas/google.protobuf.DoubleValue"
+              }
+            },
+            "title": "oneof_double_value_wrapper",
             "required": [
               "oneofDoubleValueWrapper"
             ]
           },
           {
+            "properties": {
+              "oneofEnumValue": {
+                "title": "oneof_enum_value",
+                "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
+              }
+            },
+            "title": "oneof_enum_value",
             "required": [
               "oneofEnumValue"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "oneofDoubleValue"
-                  ]
-                },
-                {
-                  "required": [
-                    "oneofDoubleValueWrapper"
-                  ]
-                },
-                {
-                  "required": [
-                    "oneofEnumValue"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -1782,19 +1743,6 @@
               "$ref": "#/components/schemas/google.protobuf.DoubleValue"
             },
             "title": "double_value_list"
-          },
-          "oneofDoubleValue": {
-            "type": "number",
-            "title": "oneof_double_value",
-            "format": "double"
-          },
-          "oneofDoubleValueWrapper": {
-            "title": "oneof_double_value_wrapper",
-            "$ref": "#/components/schemas/google.protobuf.DoubleValue"
-          },
-          "oneofEnumValue": {
-            "title": "oneof_enum_value",
-            "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
           },
           "nested": {
             "title": "nested",

--- a/internal/converter/testdata/standard/output/test.openapi.yaml
+++ b/internal/converter/testdata/standard/output/test.openapi.yaml
@@ -528,77 +528,148 @@ components:
          The JSON representation for `Value` is JSON value.
     test.v1.AllTypes:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            boolOption:
+              type: boolean
+              title: bool_option
+          title: bool_option
+          required:
             - boolOption
-        - required:
+        - properties:
+            bytesOption:
+              type: string
+              title: bytes_option
+              format: byte
+          title: bytes_option
+          required:
             - bytesOption
-        - required:
+        - properties:
+            doubleOption:
+              type: number
+              title: double_option
+              format: double
+              deprecated: true
+          title: double_option
+          required:
             - doubleOption
-        - required:
+        - properties:
+            enumOption:
+              title: enum_option
+              $ref: '#/components/schemas/test.v1.AllTypes.Enum'
+          title: enum_option
+          required:
             - enumOption
-        - required:
+        - properties:
+            fixed32Option:
+              type: integer
+              title: fixed32_option
+          title: fixed32_option
+          required:
             - fixed32Option
-        - required:
+        - properties:
+            fixed64Option:
+              type:
+                - integer
+                - string
+              title: fixed64_option
+              format: int64
+          title: fixed64_option
+          required:
             - fixed64Option
-        - required:
+        - properties:
+            floatOption:
+              type: number
+              title: float_option
+              format: float
+          title: float_option
+          required:
             - floatOption
-        - required:
+        - properties:
+            int32Option:
+              type: integer
+              title: int32_option
+              format: int32
+          title: int32_option
+          required:
             - int32Option
-        - required:
+        - properties:
+            int64Option:
+              type:
+                - integer
+                - string
+              title: int64_option
+              format: int64
+          title: int64_option
+          required:
             - int64Option
-        - required:
+        - properties:
+            msgOption:
+              title: msg_option
+              $ref: '#/components/schemas/test.v1.AllTypes'
+          title: msg_option
+          required:
             - msgOption
-        - required:
+        - properties:
+            sfixed32Option:
+              type: integer
+              title: sfixed32_option
+              format: int32
+          title: sfixed32_option
+          required:
             - sfixed32Option
-        - required:
+        - properties:
+            sfixed64Option:
+              type:
+                - integer
+                - string
+              title: sfixed64_option
+              format: int64
+          title: sfixed64_option
+          required:
             - sfixed64Option
-        - required:
+        - properties:
+            sint32Option:
+              type: integer
+              title: sint32_option
+              format: int32
+          title: sint32_option
+          required:
             - sint32Option
-        - required:
+        - properties:
+            sint64Option:
+              type:
+                - integer
+                - string
+              title: sint64_option
+              format: int64
+          title: sint64_option
+          required:
             - sint64Option
-        - required:
+        - properties:
+            stringOption:
+              type: string
+              title: string_option
+          title: string_option
+          required:
             - stringOption
-        - required:
+        - properties:
+            uint32Option:
+              type: integer
+              title: uint32_option
+          title: uint32_option
+          required:
             - uint32Option
-        - required:
+        - properties:
+            uint64Option:
+              type:
+                - integer
+                - string
+              title: uint64_option
+              format: int64
+          title: uint64_option
+          required:
             - uint64Option
-        - not:
-            anyOf:
-              - required:
-                  - boolOption
-              - required:
-                  - bytesOption
-              - required:
-                  - doubleOption
-              - required:
-                  - enumOption
-              - required:
-                  - fixed32Option
-              - required:
-                  - fixed64Option
-              - required:
-                  - floatOption
-              - required:
-                  - int32Option
-              - required:
-                  - int64Option
-              - required:
-                  - msgOption
-              - required:
-                  - sfixed32Option
-              - required:
-                  - sfixed64Option
-              - required:
-                  - sint32Option
-              - required:
-                  - sint64Option
-              - required:
-                  - stringOption
-              - required:
-                  - uint32Option
-              - required:
-                  - uint64Option
       properties:
         doubleValue:
           type: number
@@ -1070,79 +1141,6 @@ components:
           additionalProperties:
             title: value
             $ref: '#/components/schemas/test.v1.AllTypes.Enum'
-        doubleOption:
-          type: number
-          title: double_option
-          format: double
-          deprecated: true
-        floatOption:
-          type: number
-          title: float_option
-          format: float
-        int32Option:
-          type: integer
-          title: int32_option
-          format: int32
-        int64Option:
-          type:
-            - integer
-            - string
-          title: int64_option
-          format: int64
-        uint32Option:
-          type: integer
-          title: uint32_option
-        uint64Option:
-          type:
-            - integer
-            - string
-          title: uint64_option
-          format: int64
-        sint32Option:
-          type: integer
-          title: sint32_option
-          format: int32
-        sint64Option:
-          type:
-            - integer
-            - string
-          title: sint64_option
-          format: int64
-        fixed32Option:
-          type: integer
-          title: fixed32_option
-        fixed64Option:
-          type:
-            - integer
-            - string
-          title: fixed64_option
-          format: int64
-        sfixed32Option:
-          type: integer
-          title: sfixed32_option
-          format: int32
-        sfixed64Option:
-          type:
-            - integer
-            - string
-          title: sfixed64_option
-          format: int64
-        boolOption:
-          type: boolean
-          title: bool_option
-        stringOption:
-          type: string
-          title: string_option
-        bytesOption:
-          type: string
-          title: bytes_option
-          format: byte
-        msgOption:
-          title: msg_option
-          $ref: '#/components/schemas/test.v1.AllTypes'
-        enumOption:
-          title: enum_option
-          $ref: '#/components/schemas/test.v1.AllTypes.Enum'
       title: AllTypes
       additionalProperties: false
     test.v1.AllTypes.BoolMapEntry:
@@ -1505,21 +1503,29 @@ components:
       additionalProperties: false
     test.v1.ParameterValues:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            oneofDoubleValue:
+              type: number
+              title: oneof_double_value
+              format: double
+          title: oneof_double_value
+          required:
             - oneofDoubleValue
-        - required:
+        - properties:
+            oneofDoubleValueWrapper:
+              title: oneof_double_value_wrapper
+              $ref: '#/components/schemas/google.protobuf.DoubleValue'
+          title: oneof_double_value_wrapper
+          required:
             - oneofDoubleValueWrapper
-        - required:
+        - properties:
+            oneofEnumValue:
+              title: oneof_enum_value
+              $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
+          title: oneof_enum_value
+          required:
             - oneofEnumValue
-        - not:
-            anyOf:
-              - required:
-                  - oneofDoubleValue
-              - required:
-                  - oneofDoubleValueWrapper
-              - required:
-                  - oneofEnumValue
       properties:
         doubleValue:
           type: number
@@ -1646,16 +1652,6 @@ components:
           items:
             $ref: '#/components/schemas/google.protobuf.DoubleValue'
           title: double_value_list
-        oneofDoubleValue:
-          type: number
-          title: oneof_double_value
-          format: double
-        oneofDoubleValueWrapper:
-          title: oneof_double_value_wrapper
-          $ref: '#/components/schemas/google.protobuf.DoubleValue'
-        oneofEnumValue:
-          title: oneof_enum_value
-          $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
         nested:
           title: nested
           $ref: '#/components/schemas/test.v1.ParameterValues.Nested'

--- a/internal/converter/testdata/with_proto_annotations/output/test.openapi.json
+++ b/internal/converter/testdata/with_proto_annotations/output/test.openapi.json
@@ -202,182 +202,253 @@
       },
       "with_proto_annotations.test.v1.AllTypes": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "boolOption": {
+                "type": "boolean",
+                "title": "bool_option",
+                "description": "(proto bool)"
+              }
+            },
+            "title": "bool_option",
             "required": [
               "boolOption"
             ]
           },
           {
+            "properties": {
+              "bytesOption": {
+                "type": "string",
+                "title": "bytes_option",
+                "format": "byte",
+                "description": "(proto bytes)"
+              }
+            },
+            "title": "bytes_option",
             "required": [
               "bytesOption"
             ]
           },
           {
+            "properties": {
+              "doubleOption": {
+                "type": "number",
+                "title": "double_option",
+                "format": "double",
+                "description": "(proto double)"
+              }
+            },
+            "title": "double_option",
             "required": [
               "doubleOption"
             ]
           },
           {
+            "properties": {
+              "enumOption": {
+                "title": "enum_option",
+                "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)",
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
+              }
+            },
+            "title": "enum_option",
             "required": [
               "enumOption"
             ]
           },
           {
+            "properties": {
+              "fixed32Option": {
+                "type": "integer",
+                "title": "fixed32_option",
+                "description": "(proto fixed32)"
+              }
+            },
+            "title": "fixed32_option",
             "required": [
               "fixed32Option"
             ]
           },
           {
+            "properties": {
+              "fixed64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "fixed64_option",
+                "format": "int64",
+                "description": "(proto fixed64)"
+              }
+            },
+            "title": "fixed64_option",
             "required": [
               "fixed64Option"
             ]
           },
           {
+            "properties": {
+              "floatOption": {
+                "type": "number",
+                "title": "float_option",
+                "format": "float",
+                "description": "(proto float)"
+              }
+            },
+            "title": "float_option",
             "required": [
               "floatOption"
             ]
           },
           {
+            "properties": {
+              "int32Option": {
+                "type": "integer",
+                "title": "int32_option",
+                "format": "int32",
+                "description": "(proto int32)"
+              }
+            },
+            "title": "int32_option",
             "required": [
               "int32Option"
             ]
           },
           {
+            "properties": {
+              "int64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "int64_option",
+                "format": "int64",
+                "description": "(proto int64)"
+              }
+            },
+            "title": "int64_option",
             "required": [
               "int64Option"
             ]
           },
           {
+            "properties": {
+              "msgOption": {
+                "title": "msg_option",
+                "description": "(proto with_proto_annotations.test.v1.AllTypes)",
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
+              }
+            },
+            "title": "msg_option",
             "required": [
               "msgOption"
             ]
           },
           {
+            "properties": {
+              "sfixed32Option": {
+                "type": "integer",
+                "title": "sfixed32_option",
+                "format": "int32",
+                "description": "(proto sfixed32)"
+              }
+            },
+            "title": "sfixed32_option",
             "required": [
               "sfixed32Option"
             ]
           },
           {
+            "properties": {
+              "sfixed64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "sfixed64_option",
+                "format": "int64",
+                "description": "(proto sfixed64)"
+              }
+            },
+            "title": "sfixed64_option",
             "required": [
               "sfixed64Option"
             ]
           },
           {
+            "properties": {
+              "sint32Option": {
+                "type": "integer",
+                "title": "sint32_option",
+                "format": "int32",
+                "description": "(proto sint32)"
+              }
+            },
+            "title": "sint32_option",
             "required": [
               "sint32Option"
             ]
           },
           {
+            "properties": {
+              "sint64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "sint64_option",
+                "format": "int64",
+                "description": "(proto sint64)"
+              }
+            },
+            "title": "sint64_option",
             "required": [
               "sint64Option"
             ]
           },
           {
+            "properties": {
+              "stringOption": {
+                "type": "string",
+                "title": "string_option",
+                "description": "(proto string)"
+              }
+            },
+            "title": "string_option",
             "required": [
               "stringOption"
             ]
           },
           {
+            "properties": {
+              "uint32Option": {
+                "type": "integer",
+                "title": "uint32_option",
+                "description": "(proto uint32)"
+              }
+            },
+            "title": "uint32_option",
             "required": [
               "uint32Option"
             ]
           },
           {
+            "properties": {
+              "uint64Option": {
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "title": "uint64_option",
+                "format": "int64",
+                "description": "(proto uint64)"
+              }
+            },
+            "title": "uint64_option",
             "required": [
               "uint64Option"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "boolOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "bytesOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "doubleOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "enumOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "fixed32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "fixed64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "floatOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "int32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "int64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "msgOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "sfixed32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "sfixed64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "sint32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "sint64Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "stringOption"
-                  ]
-                },
-                {
-                  "required": [
-                    "uint32Option"
-                  ]
-                },
-                {
-                  "required": [
-                    "uint64Option"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -1097,117 +1168,6 @@
               "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
             },
             "description": "(proto with_proto_annotations.test.v1.AllTypes.EnumMapEntry)"
-          },
-          "doubleOption": {
-            "type": "number",
-            "title": "double_option",
-            "format": "double",
-            "description": "(proto double)"
-          },
-          "floatOption": {
-            "type": "number",
-            "title": "float_option",
-            "format": "float",
-            "description": "(proto float)"
-          },
-          "int32Option": {
-            "type": "integer",
-            "title": "int32_option",
-            "format": "int32",
-            "description": "(proto int32)"
-          },
-          "int64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "int64_option",
-            "format": "int64",
-            "description": "(proto int64)"
-          },
-          "uint32Option": {
-            "type": "integer",
-            "title": "uint32_option",
-            "description": "(proto uint32)"
-          },
-          "uint64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "uint64_option",
-            "format": "int64",
-            "description": "(proto uint64)"
-          },
-          "sint32Option": {
-            "type": "integer",
-            "title": "sint32_option",
-            "format": "int32",
-            "description": "(proto sint32)"
-          },
-          "sint64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "sint64_option",
-            "format": "int64",
-            "description": "(proto sint64)"
-          },
-          "fixed32Option": {
-            "type": "integer",
-            "title": "fixed32_option",
-            "description": "(proto fixed32)"
-          },
-          "fixed64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "fixed64_option",
-            "format": "int64",
-            "description": "(proto fixed64)"
-          },
-          "sfixed32Option": {
-            "type": "integer",
-            "title": "sfixed32_option",
-            "format": "int32",
-            "description": "(proto sfixed32)"
-          },
-          "sfixed64Option": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "title": "sfixed64_option",
-            "format": "int64",
-            "description": "(proto sfixed64)"
-          },
-          "boolOption": {
-            "type": "boolean",
-            "title": "bool_option",
-            "description": "(proto bool)"
-          },
-          "stringOption": {
-            "type": "string",
-            "title": "string_option",
-            "description": "(proto string)"
-          },
-          "bytesOption": {
-            "type": "string",
-            "title": "bytes_option",
-            "format": "byte",
-            "description": "(proto bytes)"
-          },
-          "msgOption": {
-            "title": "msg_option",
-            "description": "(proto with_proto_annotations.test.v1.AllTypes)",
-            "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
-          },
-          "enumOption": {
-            "title": "enum_option",
-            "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)",
-            "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
           }
         },
         "title": "AllTypes",
@@ -1757,42 +1717,46 @@
       },
       "with_proto_annotations.test.v1.ParameterValues": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
           {
+            "properties": {
+              "oneofDoubleValue": {
+                "type": "number",
+                "title": "oneof_double_value",
+                "format": "double",
+                "description": "(proto double)"
+              }
+            },
+            "title": "oneof_double_value",
             "required": [
               "oneofDoubleValue"
             ]
           },
           {
+            "properties": {
+              "oneofDoubleValueWrapper": {
+                "title": "oneof_double_value_wrapper",
+                "description": "(proto google.protobuf.DoubleValue)",
+                "$ref": "#/components/schemas/google.protobuf.DoubleValue"
+              }
+            },
+            "title": "oneof_double_value_wrapper",
             "required": [
               "oneofDoubleValueWrapper"
             ]
           },
           {
+            "properties": {
+              "oneofEnumValue": {
+                "title": "oneof_enum_value",
+                "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)",
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
+              }
+            },
+            "title": "oneof_enum_value",
             "required": [
               "oneofEnumValue"
             ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "oneofDoubleValue"
-                  ]
-                },
-                {
-                  "required": [
-                    "oneofDoubleValueWrapper"
-                  ]
-                },
-                {
-                  "required": [
-                    "oneofEnumValue"
-                  ]
-                }
-              ]
-            }
           }
         ],
         "properties": {
@@ -1986,22 +1950,6 @@
             },
             "title": "double_value_list",
             "description": "(proto google.protobuf.DoubleValue)"
-          },
-          "oneofDoubleValue": {
-            "type": "number",
-            "title": "oneof_double_value",
-            "format": "double",
-            "description": "(proto double)"
-          },
-          "oneofDoubleValueWrapper": {
-            "title": "oneof_double_value_wrapper",
-            "description": "(proto google.protobuf.DoubleValue)",
-            "$ref": "#/components/schemas/google.protobuf.DoubleValue"
-          },
-          "oneofEnumValue": {
-            "title": "oneof_enum_value",
-            "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)",
-            "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
           },
           "nested": {
             "title": "nested",

--- a/internal/converter/testdata/with_proto_annotations/output/test.openapi.yaml
+++ b/internal/converter/testdata/with_proto_annotations/output/test.openapi.yaml
@@ -530,77 +530,164 @@ components:
          The JSON representation for `Value` is JSON value.
     with_proto_annotations.test.v1.AllTypes:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            boolOption:
+              type: boolean
+              title: bool_option
+              description: (proto bool)
+          title: bool_option
+          required:
             - boolOption
-        - required:
+        - properties:
+            bytesOption:
+              type: string
+              title: bytes_option
+              format: byte
+              description: (proto bytes)
+          title: bytes_option
+          required:
             - bytesOption
-        - required:
+        - properties:
+            doubleOption:
+              type: number
+              title: double_option
+              format: double
+              description: (proto double)
+          title: double_option
+          required:
             - doubleOption
-        - required:
+        - properties:
+            enumOption:
+              title: enum_option
+              description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+              $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
+          title: enum_option
+          required:
             - enumOption
-        - required:
+        - properties:
+            fixed32Option:
+              type: integer
+              title: fixed32_option
+              description: (proto fixed32)
+          title: fixed32_option
+          required:
             - fixed32Option
-        - required:
+        - properties:
+            fixed64Option:
+              type:
+                - integer
+                - string
+              title: fixed64_option
+              format: int64
+              description: (proto fixed64)
+          title: fixed64_option
+          required:
             - fixed64Option
-        - required:
+        - properties:
+            floatOption:
+              type: number
+              title: float_option
+              format: float
+              description: (proto float)
+          title: float_option
+          required:
             - floatOption
-        - required:
+        - properties:
+            int32Option:
+              type: integer
+              title: int32_option
+              format: int32
+              description: (proto int32)
+          title: int32_option
+          required:
             - int32Option
-        - required:
+        - properties:
+            int64Option:
+              type:
+                - integer
+                - string
+              title: int64_option
+              format: int64
+              description: (proto int64)
+          title: int64_option
+          required:
             - int64Option
-        - required:
+        - properties:
+            msgOption:
+              title: msg_option
+              description: (proto with_proto_annotations.test.v1.AllTypes)
+              $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
+          title: msg_option
+          required:
             - msgOption
-        - required:
+        - properties:
+            sfixed32Option:
+              type: integer
+              title: sfixed32_option
+              format: int32
+              description: (proto sfixed32)
+          title: sfixed32_option
+          required:
             - sfixed32Option
-        - required:
+        - properties:
+            sfixed64Option:
+              type:
+                - integer
+                - string
+              title: sfixed64_option
+              format: int64
+              description: (proto sfixed64)
+          title: sfixed64_option
+          required:
             - sfixed64Option
-        - required:
+        - properties:
+            sint32Option:
+              type: integer
+              title: sint32_option
+              format: int32
+              description: (proto sint32)
+          title: sint32_option
+          required:
             - sint32Option
-        - required:
+        - properties:
+            sint64Option:
+              type:
+                - integer
+                - string
+              title: sint64_option
+              format: int64
+              description: (proto sint64)
+          title: sint64_option
+          required:
             - sint64Option
-        - required:
+        - properties:
+            stringOption:
+              type: string
+              title: string_option
+              description: (proto string)
+          title: string_option
+          required:
             - stringOption
-        - required:
+        - properties:
+            uint32Option:
+              type: integer
+              title: uint32_option
+              description: (proto uint32)
+          title: uint32_option
+          required:
             - uint32Option
-        - required:
+        - properties:
+            uint64Option:
+              type:
+                - integer
+                - string
+              title: uint64_option
+              format: int64
+              description: (proto uint64)
+          title: uint64_option
+          required:
             - uint64Option
-        - not:
-            anyOf:
-              - required:
-                  - boolOption
-              - required:
-                  - bytesOption
-              - required:
-                  - doubleOption
-              - required:
-                  - enumOption
-              - required:
-                  - fixed32Option
-              - required:
-                  - fixed64Option
-              - required:
-                  - floatOption
-              - required:
-                  - int32Option
-              - required:
-                  - int64Option
-              - required:
-                  - msgOption
-              - required:
-                  - sfixed32Option
-              - required:
-                  - sfixed64Option
-              - required:
-                  - sint32Option
-              - required:
-                  - sint64Option
-              - required:
-                  - stringOption
-              - required:
-                  - uint32Option
-              - required:
-                  - uint64Option
       properties:
         doubleValue:
           type: number
@@ -1173,95 +1260,6 @@ components:
             description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
             $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
           description: (proto with_proto_annotations.test.v1.AllTypes.EnumMapEntry)
-        doubleOption:
-          type: number
-          title: double_option
-          format: double
-          description: (proto double)
-        floatOption:
-          type: number
-          title: float_option
-          format: float
-          description: (proto float)
-        int32Option:
-          type: integer
-          title: int32_option
-          format: int32
-          description: (proto int32)
-        int64Option:
-          type:
-            - integer
-            - string
-          title: int64_option
-          format: int64
-          description: (proto int64)
-        uint32Option:
-          type: integer
-          title: uint32_option
-          description: (proto uint32)
-        uint64Option:
-          type:
-            - integer
-            - string
-          title: uint64_option
-          format: int64
-          description: (proto uint64)
-        sint32Option:
-          type: integer
-          title: sint32_option
-          format: int32
-          description: (proto sint32)
-        sint64Option:
-          type:
-            - integer
-            - string
-          title: sint64_option
-          format: int64
-          description: (proto sint64)
-        fixed32Option:
-          type: integer
-          title: fixed32_option
-          description: (proto fixed32)
-        fixed64Option:
-          type:
-            - integer
-            - string
-          title: fixed64_option
-          format: int64
-          description: (proto fixed64)
-        sfixed32Option:
-          type: integer
-          title: sfixed32_option
-          format: int32
-          description: (proto sfixed32)
-        sfixed64Option:
-          type:
-            - integer
-            - string
-          title: sfixed64_option
-          format: int64
-          description: (proto sfixed64)
-        boolOption:
-          type: boolean
-          title: bool_option
-          description: (proto bool)
-        stringOption:
-          type: string
-          title: string_option
-          description: (proto string)
-        bytesOption:
-          type: string
-          title: bytes_option
-          format: byte
-          description: (proto bytes)
-        msgOption:
-          title: msg_option
-          description: (proto with_proto_annotations.test.v1.AllTypes)
-          $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
-        enumOption:
-          title: enum_option
-          description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
-          $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
       title: AllTypes
       additionalProperties: false
     with_proto_annotations.test.v1.AllTypes.BoolMapEntry:
@@ -1682,21 +1680,32 @@ components:
       additionalProperties: false
     with_proto_annotations.test.v1.ParameterValues:
       type: object
-      anyOf:
-        - required:
+      oneOf:
+        - properties:
+            oneofDoubleValue:
+              type: number
+              title: oneof_double_value
+              format: double
+              description: (proto double)
+          title: oneof_double_value
+          required:
             - oneofDoubleValue
-        - required:
+        - properties:
+            oneofDoubleValueWrapper:
+              title: oneof_double_value_wrapper
+              description: (proto google.protobuf.DoubleValue)
+              $ref: '#/components/schemas/google.protobuf.DoubleValue'
+          title: oneof_double_value_wrapper
+          required:
             - oneofDoubleValueWrapper
-        - required:
+        - properties:
+            oneofEnumValue:
+              title: oneof_enum_value
+              description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
+              $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
+          title: oneof_enum_value
+          required:
             - oneofEnumValue
-        - not:
-            anyOf:
-              - required:
-                  - oneofDoubleValue
-              - required:
-                  - oneofDoubleValueWrapper
-              - required:
-                  - oneofEnumValue
       properties:
         doubleValue:
           type: number
@@ -1850,19 +1859,6 @@ components:
             $ref: '#/components/schemas/google.protobuf.DoubleValue'
           title: double_value_list
           description: (proto google.protobuf.DoubleValue)
-        oneofDoubleValue:
-          type: number
-          title: oneof_double_value
-          format: double
-          description: (proto double)
-        oneofDoubleValueWrapper:
-          title: oneof_double_value_wrapper
-          description: (proto google.protobuf.DoubleValue)
-          $ref: '#/components/schemas/google.protobuf.DoubleValue'
-        oneofEnumValue:
-          title: oneof_enum_value
-          description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
-          $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
         nested:
           title: nested
           description: (proto with_proto_annotations.test.v1.ParameterValues.Nested)


### PR DESCRIPTION
## Context

Currently, `proto.oneof` is being translated using a combination of OAS `anyOf` + not `anyOf`. We found that this translation does not seem to be properly interpreted in a couple of platforms we're using to validate OAS documents, namely, [readme.io](https://readme.com/) and the official [swagger OAS editor](https://editor-next.swagger.io/).

Instead a more direct translation to the OAS `oneOf` seems to be properly interpreted by both platforms. Visually this is how the translation would change:

**Before**
```yaml
 protovalidate.CELMessage:
      type: object
      anyOf:
        - required:
            - a
        - required:
            - b
        - not:
            anyOf:
              - required:
                  - a
              - required:
                  - b
      properties:
        a:
          type: string
          title: a
          minLength: 1
        b:
          type: string
          title: b
      title: CELMessage
      additionalProperties: false
```

**After**
```yaml
 protovalidate.CELMessage:
      type: object
      oneOf:
        - properties:
            a:
              type: string
              title: a
              minLength: 1
          title: a
          required:
            - a
        - properties:
            b:
              type: string
              title: b
          title: b
          required:
            - b
      title: CELMessage
      additionalProperties: false
``` 

For the purpose of comparison I'm using both versions (before and after) of the 
 [generated OAS protovalidate.openapi.yaml file](https://github.com/sudorandom/protoc-gen-connect-openapi/blob/main/internal/converter/testdata/standard/output/protovalidate.openapi.yaml).

## Swagger Editor

### Before

<img width="1258" alt="Screenshot 2025-04-22 at 10 56 18 AM" src="https://github.com/user-attachments/assets/e3070942-bd63-4ed8-9e80-1a217ba3e28f" />

### After
<img width="1267" alt="Screenshot 2025-04-22 at 10 55 14 AM" src="https://github.com/user-attachments/assets/efb70e0e-866b-481e-a0c9-8d51cae18830" />

#### Notice how the before translations is interpreted as a list of unnamed anyOf blocks, whereas the after translation properly showcase the A an B properties under the oneOf.

## Readme

### Before ([preview link](https://bin.readme.com/s/6807b3ee0b9f53007a704f20))

<img width="583" alt="Screenshot 2025-04-22 at 11 35 21 AM" src="https://github.com/user-attachments/assets/c17e6d05-0b10-4a72-a151-d21c66153ea1" />

### After ([preview link](https://bin.readme.com/s/6807b76f0b9f53007a704f21))

<img width="597" alt="Screenshot 2025-04-22 at 11 44 30 AM" src="https://github.com/user-attachments/assets/b4f31af6-b0dd-45e3-97f5-b9791fc495ac" />

#### Notice how the before version just renders 3 "Object" dropdowns each containing both a and b which are not mutually exclusive. The after translation properly separates the A and B properties and they are mutually exclusive as expected when using the oneOf. .