### PR TITLE
fix: prevent duplicate required properties for path parameters

### DIFF
--- a/internal/converter/googleapi/paths.go
+++ b/internal/converter/googleapi/paths.go
@@ -127,6 +127,10 @@ func httpRuleToPathMap(opts options.Options, md protoreflect.MethodDescriptor, r
 		if token.Type == TokenVariable && strings.Contains(token.Value, "=") {
 			matches := namedPathPattern.FindStringSubmatch("{" + token.Value + "}")
 			if len(matches) == 3 {
+				// Store the original field name from the glob pattern to prevent it from appearing
+				// in both the path parameters and request body/query parameters
+				orignalName := matches[1]
+				fieldNamesInPath[orignalName] = struct{}{}
 				// Convert the path from the starred form to use named path parameters.
 				starredPath := matches[2]
 				parts := strings.Split(starredPath, "/")
@@ -154,19 +158,23 @@ func httpRuleToPathMap(opts options.Options, md protoreflect.MethodDescriptor, r
 	case "*":
 		if len(fieldNamesInPath) > 0 {
 			_, s := schema.MessageToSchema(opts, md.Input())
-			for name := range fieldNamesInPath {
-				s.Properties.Delete(name)
-				// Also remove from required list to prevent duplicate required properties
-				s.Required = slices.DeleteFunc(s.Required, func(s string) bool {
-					return s == name
-				})
-				// don't serialize []
-				if len(s.Required) == 0 {
-					s.Required = nil
+			if s != nil && s.Properties != nil {
+				for name := range fieldNamesInPath {
+					s.Properties.Delete(name)
+					// Also remove from required list to prevent duplicate required properties
+					if s.Required != nil {
+						s.Required = slices.DeleteFunc(s.Required, func(s string) bool {
+							return s == name
+						})
+						// don't serialize []
+						if len(s.Required) == 0 {
+							s.Required = nil
+						}
+					}
 				}
-			}
-			if s.Properties.Len() > 0 {
-				op.RequestBody = util.MethodToRequestBody(opts, md, base.CreateSchemaProxy(s), false)
+				if s.Properties.Len() > 0 {
+					op.RequestBody = util.MethodToRequestBody(opts, md, base.CreateSchemaProxy(s), false)
+				}
 			}
 		} else {
 			inputName := string(md.Input().FullName())

--- a/internal/converter/testdata/proto_names/output/googleapi.openapi.json
+++ b/internal/converter/testdata/proto_names/output/googleapi.openapi.json
@@ -178,14 +178,6 @@
             }
           },
           {
-            "name": "property_in_path",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "title": "property_in_path"
-            }
-          },
-          {
             "name": "property_in_query",
             "in": "query",
             "schema": {

--- a/internal/converter/testdata/proto_names/output/googleapi.openapi.yaml
+++ b/internal/converter/testdata/proto_names/output/googleapi.openapi.yaml
@@ -111,11 +111,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: property_in_path
-          in: query
-          schema:
-            type: string
-            title: property_in_path
         - name: property_in_query
           in: query
           schema:


### PR DESCRIPTION
Updated the handling of field names in path parameters to ensure that they are removed from the required list in the request body schema. This change addresses potential issues with duplicate required properties when path parameters are used.
It's related to #101.

So for example using an example fromt he previous PR, when converting the following:
`RunPathPatternLexer("/users/v1/{name=organizations/*/teams/*/members/*}:activate")` to a split version, it kept the `name` in the body parameters but that's not needed because the transcoder can take it from the path thus making the body parameter redundant. This PR removes that redundancy.  