### PR TITLE
perf(converter): use messages.Get() directly

### DIFF
--- a/internal/converter/schema.go
+++ b/internal/converter/schema.go
@@ -98,8 +98,7 @@ func (st *State) CollectMessage(tt protoreflect.MessageDescriptor) {
 	// Messages can have messages
 	messages := tt.Messages()
 	for i := 0; i < messages.Len(); i++ {
-		message := messages.Get(i)
-		st.CollectMessage(message)
+		st.CollectMessage(messages.Get(i))
 	}
 }
 


### PR DESCRIPTION
Use messages.Get() directly.
At the same time, maintain the same style as the two CollectXXX functions above.
