### PR TITLE
feat: emit summary if there are multiple multiple comment sections on an RPC

### DIFF
--- a/internal/converter/paths.go
+++ b/internal/converter/paths.go
@@ -233,12 +233,16 @@ func methodToOperaton(opts options.Options, method protoreflect.MethodDescriptor
 		operationId = string(service.Name()) + "_" + string(method.Name())
 	}
 
+	summary, description := util.FormatOperationComments(loc)
+	if summary == "" {
+		summary = string(method.Name())
+	}
 	op := &v3.Operation{
-		Summary:     string(method.Name()),
+		Summary:     summary,
 		OperationId: operationId,
 		Deprecated:  util.IsMethodDeprecated(method),
 		Tags:        []string{tagName},
-		Description: util.FormatComments(loc),
+		Description: description,
 	}
 
 	isStreaming := method.IsStreamingClient() || method.IsStreamingServer()

--- a/internal/converter/protovalidate/schema.go
+++ b/internal/converter/protovalidate/schema.go
@@ -167,10 +167,10 @@ func updateSchemaWithFieldRules(opts options.Options, schema *base.Schema, rules
 			predefinedRules, err := protovalidate.ResolvePredefinedRules(entry.fd)
 			if err != nil {
 				slog.Error("error resolving predefined rules", "error", err)
-				continue // Continue to next rule, don't return true to Range
+				continue
 			}
 			if predefinedRules == nil {
-				continue // Continue to next rule
+				continue
 			}
 			updateWithCEL(schema, predefinedRules.GetCel(), &entry.v, entry.fd)
 		}

--- a/internal/converter/testdata/path_prefix/output/path_prefixes.openapi.json
+++ b/internal/converter/testdata/path_prefix/output/path_prefixes.openapi.json
@@ -9,7 +9,7 @@
         "tags": [
           "path_prefixes.Greeter"
         ],
-        "summary": "SayHello",
+        "summary": "Sends a greeting",
         "description": "Sends a greeting",
         "operationId": "path_prefixes.Greeter.SayHello",
         "parameters": [
@@ -68,7 +68,7 @@
         "tags": [
           "path_prefixes.Greeter"
         ],
-        "summary": "WriteHello",
+        "summary": "Writes a greeting (has side effects)",
         "description": "Writes a greeting (has side effects)",
         "operationId": "path_prefixes.Greeter.WriteHello",
         "parameters": [

--- a/internal/converter/testdata/path_prefix/output/path_prefixes.openapi.yaml
+++ b/internal/converter/testdata/path_prefix/output/path_prefixes.openapi.yaml
@@ -6,7 +6,7 @@ paths:
     post:
       tags:
         - path_prefixes.Greeter
-      summary: SayHello
+      summary: Sends a greeting
       description: Sends a greeting
       operationId: path_prefixes.Greeter.SayHello
       parameters:
@@ -42,7 +42,7 @@ paths:
     post:
       tags:
         - path_prefixes.Greeter
-      summary: WriteHello
+      summary: Writes a greeting (has side effects)
       description: Writes a greeting (has side effects)
       operationId: path_prefixes.Greeter.WriteHello
       parameters:

--- a/internal/converter/testdata/standard/output/flex.openapi.json
+++ b/internal/converter/testdata/standard/output/flex.openapi.json
@@ -10,7 +10,7 @@
         "tags": [
           "flex.FlexService"
         ],
-        "summary": "NormalRPC",
+        "summary": "Normal RPC method",
         "description": "Normal RPC method",
         "operationId": "flex.FlexService.NormalRPC",
         "parameters": [
@@ -69,7 +69,7 @@
         "tags": [
           "flex.FlexService"
         ],
-        "summary": "ClientStream",
+        "summary": "Stream from client to server",
         "description": "Stream from client to server",
         "operationId": "flex.FlexService.ClientStream",
         "parameters": [
@@ -233,7 +233,7 @@
         "tags": [
           "flex.FlexService"
         ],
-        "summary": "ServerStream",
+        "summary": "Stream from server to client",
         "description": "Stream from server to client",
         "operationId": "flex.FlexService.ServerStream",
         "parameters": [
@@ -397,7 +397,7 @@
         "tags": [
           "flex.FlexService"
         ],
-        "summary": "BiDirectorionalStream",
+        "summary": "Stream both ways",
         "description": "Stream both ways",
         "operationId": "flex.FlexService.BiDirectorionalStream",
         "parameters": [
@@ -561,7 +561,7 @@
         "tags": [
           "flex.FlexService"
         ],
-        "summary": "EmptyRPC",
+        "summary": "Don't send or receive anything",
         "description": "Don't send or receive anything",
         "operationId": "flex.FlexService.EmptyRPC",
         "parameters": [

--- a/internal/converter/testdata/standard/output/flex.openapi.yaml
+++ b/internal/converter/testdata/standard/output/flex.openapi.yaml
@@ -10,7 +10,7 @@ paths:
     post:
       tags:
         - flex.FlexService
-      summary: NormalRPC
+      summary: Normal RPC method
       description: Normal RPC method
       operationId: flex.FlexService.NormalRPC
       parameters:
@@ -46,7 +46,7 @@ paths:
     post:
       tags:
         - flex.FlexService
-      summary: ClientStream
+      summary: Stream from client to server
       description: Stream from client to server
       operationId: flex.FlexService.ClientStream
       parameters:
@@ -145,7 +145,7 @@ paths:
     post:
       tags:
         - flex.FlexService
-      summary: ServerStream
+      summary: Stream from server to client
       description: Stream from server to client
       operationId: flex.FlexService.ServerStream
       parameters:
@@ -244,7 +244,7 @@ paths:
     post:
       tags:
         - flex.FlexService
-      summary: BiDirectorionalStream
+      summary: Stream both ways
       description: Stream both ways
       operationId: flex.FlexService.BiDirectorionalStream
       parameters:
@@ -343,7 +343,7 @@ paths:
     post:
       tags:
         - flex.FlexService
-      summary: EmptyRPC
+      summary: Don't send or receive anything
       description: Don't send or receive anything
       operationId: flex.FlexService.EmptyRPC
       parameters:

--- a/internal/converter/testdata/standard/output/gnostic.openapi.json
+++ b/internal/converter/testdata/standard/output/gnostic.openapi.json
@@ -20,7 +20,7 @@
         "tags": [
           "example_with_gnostic.Greeter"
         ],
-        "summary": "SayHello",
+        "summary": "Sends a greeting",
         "description": "Sends a greeting",
         "operationId": "example_with_gnostic.Greeter.SayHello.get",
         "parameters": [
@@ -130,7 +130,7 @@
         "tags": [
           "example_with_gnostic.Greeter"
         ],
-        "summary": "SayHello",
+        "summary": "Sends a greeting",
         "description": "Sends a greeting",
         "operationId": "example_with_gnostic.Greeter.SayHello",
         "parameters": [

--- a/internal/converter/testdata/standard/output/gnostic.openapi.yaml
+++ b/internal/converter/testdata/standard/output/gnostic.openapi.yaml
@@ -20,7 +20,7 @@ paths:
     get:
       tags:
         - example_with_gnostic.Greeter
-      summary: SayHello
+      summary: Sends a greeting
       description: Sends a greeting
       operationId: example_with_gnostic.Greeter.SayHello.get
       parameters:
@@ -85,7 +85,7 @@ paths:
     post:
       tags:
         - example_with_gnostic.Greeter
-      summary: SayHello
+      summary: Sends a greeting
       description: Sends a greeting
       operationId: example_with_gnostic.Greeter.SayHello
       parameters:

--- a/internal/converter/testdata/standard/output/helloworld.openapi.json
+++ b/internal/converter/testdata/standard/output/helloworld.openapi.json
@@ -10,7 +10,7 @@
         "tags": [
           "helloworld.Greeter"
         ],
-        "summary": "SayHello",
+        "summary": "Sends a greeting",
         "description": "Sends a greeting",
         "operationId": "helloworld.Greeter.SayHello.get",
         "parameters": [
@@ -97,7 +97,7 @@
         "tags": [
           "helloworld.Greeter"
         ],
-        "summary": "SayHello",
+        "summary": "Sends a greeting",
         "description": "Sends a greeting",
         "operationId": "helloworld.Greeter.SayHello",
         "parameters": [
@@ -156,7 +156,7 @@
         "tags": [
           "helloworld.Greeter"
         ],
-        "summary": "WriteHello",
+        "summary": "Writes a greeting (has side effects)",
         "description": "Writes a greeting (has side effects)",
         "operationId": "helloworld.Greeter.WriteHello",
         "parameters": [

--- a/internal/converter/testdata/standard/output/helloworld.openapi.yaml
+++ b/internal/converter/testdata/standard/output/helloworld.openapi.yaml
@@ -10,7 +10,7 @@ paths:
     get:
       tags:
         - helloworld.Greeter
-      summary: SayHello
+      summary: Sends a greeting
       description: Sends a greeting
       operationId: helloworld.Greeter.SayHello.get
       parameters:
@@ -62,7 +62,7 @@ paths:
     post:
       tags:
         - helloworld.Greeter
-      summary: SayHello
+      summary: Sends a greeting
       description: Sends a greeting
       operationId: helloworld.Greeter.SayHello
       parameters:
@@ -98,7 +98,7 @@ paths:
     post:
       tags:
         - helloworld.Greeter
-      summary: WriteHello
+      summary: Writes a greeting (has side effects)
       description: Writes a greeting (has side effects)
       operationId: helloworld.Greeter.WriteHello
       parameters:

--- a/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.json
@@ -275,7 +275,7 @@
             "title": "val",
             "maximum": 128,
             "minimum": 256,
-            "description": "fixed32.lte = 128\nfixed32.gte = 256\nfixed32.gte_lt = 256\nfixed32.gte_lt_exclusive = 256\nfixed32.gte_lte = 256\nfixed32.gte_lte_exclusive = 256\n"
+            "description": "fixed32.gte = 256\nfixed32.gte_lt = 256\nfixed32.gte_lt_exclusive = 256\nfixed32.gte_lte = 256\nfixed32.gte_lte_exclusive = 256\nfixed32.lte = 128\n"
           }
         },
         "title": "Fixed32ExGTELTE",
@@ -289,7 +289,7 @@
             "exclusiveMinimum": 10,
             "type": "integer",
             "title": "val",
-            "description": "fixed32.lt = 5\nfixed32.gt = 10\nfixed32.gt_lt = 10\nfixed32.gt_lt_exclusive = 10\nfixed32.gt_lte = 10\nfixed32.gt_lte_exclusive = 10\n"
+            "description": "fixed32.gt = 10\nfixed32.gt_lt = 10\nfixed32.gt_lt_exclusive = 10\nfixed32.gt_lte = 10\nfixed32.gt_lte_exclusive = 10\nfixed32.lt = 5\n"
           }
         },
         "title": "Fixed32ExLTGT",
@@ -344,7 +344,7 @@
             "title": "val",
             "maximum": 256,
             "minimum": 128,
-            "description": "fixed32.lte = 256\nfixed32.gte = 128\nfixed32.gte_lt = 128\nfixed32.gte_lt_exclusive = 128\nfixed32.gte_lte = 128\nfixed32.gte_lte_exclusive = 128\n"
+            "description": "fixed32.gte = 128\nfixed32.gte_lt = 128\nfixed32.gte_lt_exclusive = 128\nfixed32.gte_lte = 128\nfixed32.gte_lte_exclusive = 128\nfixed32.lte = 256\n"
           }
         },
         "title": "Fixed32GTELTE",
@@ -358,7 +358,7 @@
             "exclusiveMinimum": 5,
             "type": "integer",
             "title": "val",
-            "description": "fixed32.lt = 10\nfixed32.gt = 5\nfixed32.gt_lt = 5\nfixed32.gt_lt_exclusive = 5\nfixed32.gt_lte = 5\nfixed32.gt_lte_exclusive = 5\n"
+            "description": "fixed32.gt = 5\nfixed32.gt_lt = 5\nfixed32.gt_lt_exclusive = 5\nfixed32.gt_lte = 5\nfixed32.gt_lte_exclusive = 5\nfixed32.lt = 10\n"
           }
         },
         "title": "Fixed32GTLT",
@@ -372,7 +372,7 @@
             "title": "val",
             "maximum": 256,
             "minimum": 128,
-            "description": "fixed32.lte = 256\nfixed32.gte = 128\nfixed32.gte_lt = 128\nfixed32.gte_lt_exclusive = 128\nfixed32.gte_lte = 128\nfixed32.gte_lte_exclusive = 128\n"
+            "description": "fixed32.gte = 128\nfixed32.gte_lt = 128\nfixed32.gte_lt_exclusive = 128\nfixed32.gte_lte = 128\nfixed32.gte_lte_exclusive = 128\nfixed32.lte = 256\n"
           }
         },
         "title": "Fixed32Ignore",
@@ -490,7 +490,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int64",
-            "description": "fixed64.lte = 128\nfixed64.gte = 256\nfixed64.gte_lt = 256\nfixed64.gte_lt_exclusive = 256\nfixed64.gte_lte = 256\nfixed64.gte_lte_exclusive = 256\n"
+            "description": "fixed64.gte = 256\nfixed64.gte_lt = 256\nfixed64.gte_lt_exclusive = 256\nfixed64.gte_lte = 256\nfixed64.gte_lte_exclusive = 256\nfixed64.lte = 128\n"
           }
         },
         "title": "Fixed64ExGTELTE",
@@ -508,7 +508,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "fixed64.lt = 5\nfixed64.gt = 10\nfixed64.gt_lt = 10\nfixed64.gt_lt_exclusive = 10\nfixed64.gt_lte = 10\nfixed64.gt_lte_exclusive = 10\n"
+            "description": "fixed64.gt = 10\nfixed64.gt_lt = 10\nfixed64.gt_lt_exclusive = 10\nfixed64.gt_lte = 10\nfixed64.gt_lte_exclusive = 10\nfixed64.lt = 5\n"
           }
         },
         "title": "Fixed64ExLTGT",
@@ -579,7 +579,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "fixed64.lte = 256\nfixed64.gte = 128\nfixed64.gte_lt = 128\nfixed64.gte_lt_exclusive = 128\nfixed64.gte_lte = 128\nfixed64.gte_lte_exclusive = 128\n"
+            "description": "fixed64.gte = 128\nfixed64.gte_lt = 128\nfixed64.gte_lt_exclusive = 128\nfixed64.gte_lte = 128\nfixed64.gte_lte_exclusive = 128\nfixed64.lte = 256\n"
           }
         },
         "title": "Fixed64GTELTE",
@@ -597,7 +597,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "fixed64.lt = 10\nfixed64.gt = 5\nfixed64.gt_lt = 5\nfixed64.gt_lt_exclusive = 5\nfixed64.gt_lte = 5\nfixed64.gt_lte_exclusive = 5\n"
+            "description": "fixed64.gt = 5\nfixed64.gt_lt = 5\nfixed64.gt_lt_exclusive = 5\nfixed64.gt_lte = 5\nfixed64.gt_lte_exclusive = 5\nfixed64.lt = 10\n"
           }
         },
         "title": "Fixed64GTLT",
@@ -615,7 +615,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "fixed64.lte = 256\nfixed64.gte = 128\nfixed64.gte_lt = 128\nfixed64.gte_lt_exclusive = 128\nfixed64.gte_lte = 128\nfixed64.gte_lte_exclusive = 128\n"
+            "description": "fixed64.gte = 128\nfixed64.gte_lt = 128\nfixed64.gte_lt_exclusive = 128\nfixed64.gte_lte = 128\nfixed64.gte_lte_exclusive = 128\nfixed64.lte = 256\n"
           }
         },
         "title": "Fixed64Ignore",
@@ -985,7 +985,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int32",
-            "description": "int32.lte = 128\nint32.gte = 256\nint32.gte_lt = 256\nint32.gte_lt_exclusive = 256\nint32.gte_lte = 256\nint32.gte_lte_exclusive = 256\n"
+            "description": "int32.gte = 256\nint32.gte_lt = 256\nint32.gte_lt_exclusive = 256\nint32.gte_lte = 256\nint32.gte_lte_exclusive = 256\nint32.lte = 128\n"
           }
         },
         "title": "Int32ExGTELTE",
@@ -1000,7 +1000,7 @@
             "type": "integer",
             "title": "val",
             "format": "int32",
-            "description": "int32.lt = 0\nint32.gt = 10\nint32.gt_lt = 10\nint32.gt_lt_exclusive = 10\nint32.gt_lte = 10\nint32.gt_lte_exclusive = 10\n"
+            "description": "int32.gt = 10\nint32.gt_lt = 10\nint32.gt_lt_exclusive = 10\nint32.gt_lte = 10\nint32.gt_lte_exclusive = 10\nint32.lt = 0\n"
           }
         },
         "title": "Int32ExLTGT",
@@ -1059,7 +1059,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int32",
-            "description": "int32.lte = 256\nint32.gte = 128\nint32.gte_lt = 128\nint32.gte_lt_exclusive = 128\nint32.gte_lte = 128\nint32.gte_lte_exclusive = 128\n"
+            "description": "int32.gte = 128\nint32.gte_lt = 128\nint32.gte_lt_exclusive = 128\nint32.gte_lte = 128\nint32.gte_lte_exclusive = 128\nint32.lte = 256\n"
           }
         },
         "title": "Int32GTELTE",
@@ -1074,7 +1074,7 @@
             "type": "integer",
             "title": "val",
             "format": "int32",
-            "description": "int32.lt = 10\nint32.gt = 0\nint32.gt_lt = 0\nint32.gt_lt_exclusive = 0\nint32.gt_lte = 0\nint32.gt_lte_exclusive = 0\n"
+            "description": "int32.gt = 0\nint32.gt_lt = 0\nint32.gt_lt_exclusive = 0\nint32.gt_lte = 0\nint32.gt_lte_exclusive = 0\nint32.lt = 10\n"
           }
         },
         "title": "Int32GTLT",
@@ -1089,7 +1089,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int32",
-            "description": "int32.lte = 256\nint32.gte = 128\nint32.gte_lt = 128\nint32.gte_lt_exclusive = 128\nint32.gte_lte = 128\nint32.gte_lte_exclusive = 128\n"
+            "description": "int32.gte = 128\nint32.gte_lt = 128\nint32.gte_lt_exclusive = 128\nint32.gte_lte = 128\nint32.gte_lte_exclusive = 128\nint32.lte = 256\n"
           }
         },
         "title": "Int32Ignore",
@@ -1352,7 +1352,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int64",
-            "description": "int64.lte = 128\nint64.gte = 256\nint64.gte_lt = 256\nint64.gte_lt_exclusive = 256\nint64.gte_lte = 256\nint64.gte_lte_exclusive = 256\n"
+            "description": "int64.gte = 256\nint64.gte_lt = 256\nint64.gte_lt_exclusive = 256\nint64.gte_lte = 256\nint64.gte_lte_exclusive = 256\nint64.lte = 128\n"
           }
         },
         "title": "Int64ExGTELTE",
@@ -1370,7 +1370,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "int64.lt = 0\nint64.gt = 10\nint64.gt_lt = 10\nint64.gt_lt_exclusive = 10\nint64.gt_lte = 10\nint64.gt_lte_exclusive = 10\n"
+            "description": "int64.gt = 10\nint64.gt_lt = 10\nint64.gt_lt_exclusive = 10\nint64.gt_lte = 10\nint64.gt_lte_exclusive = 10\nint64.lt = 0\n"
           }
         },
         "title": "Int64ExLTGT",
@@ -1441,7 +1441,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "int64.lte = 256\nint64.gte = 128\nint64.gte_lt = 128\nint64.gte_lt_exclusive = 128\nint64.gte_lte = 128\nint64.gte_lte_exclusive = 128\n"
+            "description": "int64.gte = 128\nint64.gte_lt = 128\nint64.gte_lt_exclusive = 128\nint64.gte_lte = 128\nint64.gte_lte_exclusive = 128\nint64.lte = 256\n"
           }
         },
         "title": "Int64GTELTE",
@@ -1459,7 +1459,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "int64.lt = 10\nint64.gt = 0\nint64.gt_lt = 0\nint64.gt_lt_exclusive = 0\nint64.gt_lte = 0\nint64.gt_lte_exclusive = 0\n"
+            "description": "int64.gt = 0\nint64.gt_lt = 0\nint64.gt_lt_exclusive = 0\nint64.gt_lte = 0\nint64.gt_lte_exclusive = 0\nint64.lt = 10\n"
           }
         },
         "title": "Int64GTLT",
@@ -1477,7 +1477,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "int64.lte = 256\nint64.gte = 128\nint64.gte_lt = 128\nint64.gte_lt_exclusive = 128\nint64.gte_lte = 128\nint64.gte_lte_exclusive = 128\n"
+            "description": "int64.gte = 128\nint64.gte_lt = 128\nint64.gte_lt_exclusive = 128\nint64.gte_lte = 128\nint64.gte_lte_exclusive = 128\nint64.lte = 256\n"
           }
         },
         "title": "Int64Ignore",
@@ -1634,7 +1634,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int32",
-            "description": "sfixed32.lte = 128\nsfixed32.gte = 256\nsfixed32.gte_lt = 256\nsfixed32.gte_lt_exclusive = 256\nsfixed32.gte_lte = 256\nsfixed32.gte_lte_exclusive = 256\n"
+            "description": "sfixed32.gte = 256\nsfixed32.gte_lt = 256\nsfixed32.gte_lt_exclusive = 256\nsfixed32.gte_lte = 256\nsfixed32.gte_lte_exclusive = 256\nsfixed32.lte = 128\n"
           }
         },
         "title": "SFixed32ExGTELTE",
@@ -1649,7 +1649,7 @@
             "type": "integer",
             "title": "val",
             "format": "int32",
-            "description": "sfixed32.lt = 0\nsfixed32.gt = 10\nsfixed32.gt_lt = 10\nsfixed32.gt_lt_exclusive = 10\nsfixed32.gt_lte = 10\nsfixed32.gt_lte_exclusive = 10\n"
+            "description": "sfixed32.gt = 10\nsfixed32.gt_lt = 10\nsfixed32.gt_lt_exclusive = 10\nsfixed32.gt_lte = 10\nsfixed32.gt_lte_exclusive = 10\nsfixed32.lt = 0\n"
           }
         },
         "title": "SFixed32ExLTGT",
@@ -1708,7 +1708,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int32",
-            "description": "sfixed32.lte = 256\nsfixed32.gte = 128\nsfixed32.gte_lt = 128\nsfixed32.gte_lt_exclusive = 128\nsfixed32.gte_lte = 128\nsfixed32.gte_lte_exclusive = 128\n"
+            "description": "sfixed32.gte = 128\nsfixed32.gte_lt = 128\nsfixed32.gte_lt_exclusive = 128\nsfixed32.gte_lte = 128\nsfixed32.gte_lte_exclusive = 128\nsfixed32.lte = 256\n"
           }
         },
         "title": "SFixed32GTELTE",
@@ -1723,7 +1723,7 @@
             "type": "integer",
             "title": "val",
             "format": "int32",
-            "description": "sfixed32.lt = 10\nsfixed32.gt = 0\nsfixed32.gt_lt = 0\nsfixed32.gt_lt_exclusive = 0\nsfixed32.gt_lte = 0\nsfixed32.gt_lte_exclusive = 0\n"
+            "description": "sfixed32.gt = 0\nsfixed32.gt_lt = 0\nsfixed32.gt_lt_exclusive = 0\nsfixed32.gt_lte = 0\nsfixed32.gt_lte_exclusive = 0\nsfixed32.lt = 10\n"
           }
         },
         "title": "SFixed32GTLT",
@@ -1738,7 +1738,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int32",
-            "description": "sfixed32.lte = 256\nsfixed32.gte = 128\nsfixed32.gte_lt = 128\nsfixed32.gte_lt_exclusive = 128\nsfixed32.gte_lte = 128\nsfixed32.gte_lte_exclusive = 128\n"
+            "description": "sfixed32.gte = 128\nsfixed32.gte_lt = 128\nsfixed32.gte_lt_exclusive = 128\nsfixed32.gte_lte = 128\nsfixed32.gte_lte_exclusive = 128\nsfixed32.lte = 256\n"
           }
         },
         "title": "SFixed32Ignore",
@@ -1862,7 +1862,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int64",
-            "description": "sfixed64.lte = 128\nsfixed64.gte = 256\nsfixed64.gte_lt = 256\nsfixed64.gte_lt_exclusive = 256\nsfixed64.gte_lte = 256\nsfixed64.gte_lte_exclusive = 256\n"
+            "description": "sfixed64.gte = 256\nsfixed64.gte_lt = 256\nsfixed64.gte_lt_exclusive = 256\nsfixed64.gte_lte = 256\nsfixed64.gte_lte_exclusive = 256\nsfixed64.lte = 128\n"
           }
         },
         "title": "SFixed64ExGTELTE",
@@ -1880,7 +1880,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "sfixed64.lt = 0\nsfixed64.gt = 10\nsfixed64.gt_lt = 10\nsfixed64.gt_lt_exclusive = 10\nsfixed64.gt_lte = 10\nsfixed64.gt_lte_exclusive = 10\n"
+            "description": "sfixed64.gt = 10\nsfixed64.gt_lt = 10\nsfixed64.gt_lt_exclusive = 10\nsfixed64.gt_lte = 10\nsfixed64.gt_lte_exclusive = 10\nsfixed64.lt = 0\n"
           }
         },
         "title": "SFixed64ExLTGT",
@@ -1951,7 +1951,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "sfixed64.lte = 256\nsfixed64.gte = 128\nsfixed64.gte_lt = 128\nsfixed64.gte_lt_exclusive = 128\nsfixed64.gte_lte = 128\nsfixed64.gte_lte_exclusive = 128\n"
+            "description": "sfixed64.gte = 128\nsfixed64.gte_lt = 128\nsfixed64.gte_lt_exclusive = 128\nsfixed64.gte_lte = 128\nsfixed64.gte_lte_exclusive = 128\nsfixed64.lte = 256\n"
           }
         },
         "title": "SFixed64GTELTE",
@@ -1969,7 +1969,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "sfixed64.lt = 10\nsfixed64.gt = 0\nsfixed64.gt_lt = 0\nsfixed64.gt_lt_exclusive = 0\nsfixed64.gt_lte = 0\nsfixed64.gt_lte_exclusive = 0\n"
+            "description": "sfixed64.gt = 0\nsfixed64.gt_lt = 0\nsfixed64.gt_lt_exclusive = 0\nsfixed64.gt_lte = 0\nsfixed64.gt_lte_exclusive = 0\nsfixed64.lt = 10\n"
           }
         },
         "title": "SFixed64GTLT",
@@ -1987,7 +1987,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "sfixed64.lte = 256\nsfixed64.gte = 128\nsfixed64.gte_lt = 128\nsfixed64.gte_lt_exclusive = 128\nsfixed64.gte_lte = 128\nsfixed64.gte_lte_exclusive = 128\n"
+            "description": "sfixed64.gte = 128\nsfixed64.gte_lt = 128\nsfixed64.gte_lt_exclusive = 128\nsfixed64.gte_lte = 128\nsfixed64.gte_lte_exclusive = 128\nsfixed64.lte = 256\n"
           }
         },
         "title": "SFixed64Ignore",
@@ -2126,7 +2126,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int32",
-            "description": "sint32.lte = 128\nsint32.gte = 256\nsint32.gte_lt = 256\nsint32.gte_lt_exclusive = 256\nsint32.gte_lte = 256\nsint32.gte_lte_exclusive = 256\n"
+            "description": "sint32.gte = 256\nsint32.gte_lt = 256\nsint32.gte_lt_exclusive = 256\nsint32.gte_lte = 256\nsint32.gte_lte_exclusive = 256\nsint32.lte = 128\n"
           }
         },
         "title": "SInt32ExGTELTE",
@@ -2141,7 +2141,7 @@
             "type": "integer",
             "title": "val",
             "format": "int32",
-            "description": "sint32.lt = 0\nsint32.gt = 10\nsint32.gt_lt = 10\nsint32.gt_lt_exclusive = 10\nsint32.gt_lte = 10\nsint32.gt_lte_exclusive = 10\n"
+            "description": "sint32.gt = 10\nsint32.gt_lt = 10\nsint32.gt_lt_exclusive = 10\nsint32.gt_lte = 10\nsint32.gt_lte_exclusive = 10\nsint32.lt = 0\n"
           }
         },
         "title": "SInt32ExLTGT",
@@ -2200,7 +2200,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int32",
-            "description": "sint32.lte = 256\nsint32.gte = 128\nsint32.gte_lt = 128\nsint32.gte_lt_exclusive = 128\nsint32.gte_lte = 128\nsint32.gte_lte_exclusive = 128\n"
+            "description": "sint32.gte = 128\nsint32.gte_lt = 128\nsint32.gte_lt_exclusive = 128\nsint32.gte_lte = 128\nsint32.gte_lte_exclusive = 128\nsint32.lte = 256\n"
           }
         },
         "title": "SInt32GTELTE",
@@ -2215,7 +2215,7 @@
             "type": "integer",
             "title": "val",
             "format": "int32",
-            "description": "sint32.lt = 10\nsint32.gt = 0\nsint32.gt_lt = 0\nsint32.gt_lt_exclusive = 0\nsint32.gt_lte = 0\nsint32.gt_lte_exclusive = 0\n"
+            "description": "sint32.gt = 0\nsint32.gt_lt = 0\nsint32.gt_lt_exclusive = 0\nsint32.gt_lte = 0\nsint32.gt_lte_exclusive = 0\nsint32.lt = 10\n"
           }
         },
         "title": "SInt32GTLT",
@@ -2230,7 +2230,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int32",
-            "description": "sint32.lte = 256\nsint32.gte = 128\nsint32.gte_lt = 128\nsint32.gte_lt_exclusive = 128\nsint32.gte_lte = 128\nsint32.gte_lte_exclusive = 128\n"
+            "description": "sint32.gte = 128\nsint32.gte_lt = 128\nsint32.gte_lt_exclusive = 128\nsint32.gte_lte = 128\nsint32.gte_lte_exclusive = 128\nsint32.lte = 256\n"
           }
         },
         "title": "SInt32Ignore",
@@ -2354,7 +2354,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int64",
-            "description": "sint64.lte = 128\nsint64.gte = 256\nsint64.gte_lt = 256\nsint64.gte_lt_exclusive = 256\nsint64.gte_lte = 256\nsint64.gte_lte_exclusive = 256\n"
+            "description": "sint64.gte = 256\nsint64.gte_lt = 256\nsint64.gte_lt_exclusive = 256\nsint64.gte_lte = 256\nsint64.gte_lte_exclusive = 256\nsint64.lte = 128\n"
           }
         },
         "title": "SInt64ExGTELTE",
@@ -2372,7 +2372,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "sint64.lt = 0\nsint64.gt = 10\nsint64.gt_lt = 10\nsint64.gt_lt_exclusive = 10\nsint64.gt_lte = 10\nsint64.gt_lte_exclusive = 10\n"
+            "description": "sint64.gt = 10\nsint64.gt_lt = 10\nsint64.gt_lt_exclusive = 10\nsint64.gt_lte = 10\nsint64.gt_lte_exclusive = 10\nsint64.lt = 0\n"
           }
         },
         "title": "SInt64ExLTGT",
@@ -2443,7 +2443,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "sint64.lte = 256\nsint64.gte = 128\nsint64.gte_lt = 128\nsint64.gte_lt_exclusive = 128\nsint64.gte_lte = 128\nsint64.gte_lte_exclusive = 128\n"
+            "description": "sint64.gte = 128\nsint64.gte_lt = 128\nsint64.gte_lt_exclusive = 128\nsint64.gte_lte = 128\nsint64.gte_lte_exclusive = 128\nsint64.lte = 256\n"
           }
         },
         "title": "SInt64GTELTE",
@@ -2461,7 +2461,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "sint64.lt = 10\nsint64.gt = 0\nsint64.gt_lt = 0\nsint64.gt_lt_exclusive = 0\nsint64.gt_lte = 0\nsint64.gt_lte_exclusive = 0\n"
+            "description": "sint64.gt = 0\nsint64.gt_lt = 0\nsint64.gt_lt_exclusive = 0\nsint64.gt_lte = 0\nsint64.gt_lte_exclusive = 0\nsint64.lt = 10\n"
           }
         },
         "title": "SInt64GTLT",
@@ -2479,7 +2479,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "sint64.lte = 256\nsint64.gte = 128\nsint64.gte_lt = 128\nsint64.gte_lt_exclusive = 128\nsint64.gte_lte = 128\nsint64.gte_lte_exclusive = 128\n"
+            "description": "sint64.gte = 128\nsint64.gte_lt = 128\nsint64.gte_lt_exclusive = 128\nsint64.gte_lte = 128\nsint64.gte_lte_exclusive = 128\nsint64.lte = 256\n"
           }
         },
         "title": "SInt64Ignore",
@@ -2616,7 +2616,7 @@
             "title": "val",
             "maximum": 128,
             "minimum": 256,
-            "description": "uint32.lte = 128\nuint32.gte = 256\nuint32.gte_lt = 256\nuint32.gte_lt_exclusive = 256\nuint32.gte_lte = 256\nuint32.gte_lte_exclusive = 256\n"
+            "description": "uint32.gte = 256\nuint32.gte_lt = 256\nuint32.gte_lt_exclusive = 256\nuint32.gte_lte = 256\nuint32.gte_lte_exclusive = 256\nuint32.lte = 128\n"
           }
         },
         "title": "UInt32ExGTELTE",
@@ -2630,7 +2630,7 @@
             "exclusiveMinimum": 10,
             "type": "integer",
             "title": "val",
-            "description": "uint32.lt = 5\nuint32.gt = 10\nuint32.gt_lt = 10\nuint32.gt_lt_exclusive = 10\nuint32.gt_lte = 10\nuint32.gt_lte_exclusive = 10\n"
+            "description": "uint32.gt = 10\nuint32.gt_lt = 10\nuint32.gt_lt_exclusive = 10\nuint32.gt_lte = 10\nuint32.gt_lte_exclusive = 10\nuint32.lt = 5\n"
           }
         },
         "title": "UInt32ExLTGT",
@@ -2685,7 +2685,7 @@
             "title": "val",
             "maximum": 256,
             "minimum": 128,
-            "description": "uint32.lte = 256\nuint32.gte = 128\nuint32.gte_lt = 128\nuint32.gte_lt_exclusive = 128\nuint32.gte_lte = 128\nuint32.gte_lte_exclusive = 128\n"
+            "description": "uint32.gte = 128\nuint32.gte_lt = 128\nuint32.gte_lt_exclusive = 128\nuint32.gte_lte = 128\nuint32.gte_lte_exclusive = 128\nuint32.lte = 256\n"
           }
         },
         "title": "UInt32GTELTE",
@@ -2699,7 +2699,7 @@
             "exclusiveMinimum": 5,
             "type": "integer",
             "title": "val",
-            "description": "uint32.lt = 10\nuint32.gt = 5\nuint32.gt_lt = 5\nuint32.gt_lt_exclusive = 5\nuint32.gt_lte = 5\nuint32.gt_lte_exclusive = 5\n"
+            "description": "uint32.gt = 5\nuint32.gt_lt = 5\nuint32.gt_lt_exclusive = 5\nuint32.gt_lte = 5\nuint32.gt_lte_exclusive = 5\nuint32.lt = 10\n"
           }
         },
         "title": "UInt32GTLT",
@@ -2713,7 +2713,7 @@
             "title": "val",
             "maximum": 256,
             "minimum": 128,
-            "description": "uint32.lte = 256\nuint32.gte = 128\nuint32.gte_lt = 128\nuint32.gte_lt_exclusive = 128\nuint32.gte_lte = 128\nuint32.gte_lte_exclusive = 128\n"
+            "description": "uint32.gte = 128\nuint32.gte_lt = 128\nuint32.gte_lt_exclusive = 128\nuint32.gte_lte = 128\nuint32.gte_lte_exclusive = 128\nuint32.lte = 256\n"
           }
         },
         "title": "UInt32Ignore",
@@ -2831,7 +2831,7 @@
             "maximum": 128,
             "minimum": 256,
             "format": "int64",
-            "description": "uint64.lte = 128\nuint64.gte = 256\nuint64.gte_lt = 256\nuint64.gte_lt_exclusive = 256\nuint64.gte_lte = 256\nuint64.gte_lte_exclusive = 256\n"
+            "description": "uint64.gte = 256\nuint64.gte_lt = 256\nuint64.gte_lt_exclusive = 256\nuint64.gte_lte = 256\nuint64.gte_lte_exclusive = 256\nuint64.lte = 128\n"
           }
         },
         "title": "UInt64ExGTELTE",
@@ -2849,7 +2849,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "uint64.lt = 5\nuint64.gt = 10\nuint64.gt_lt = 10\nuint64.gt_lt_exclusive = 10\nuint64.gt_lte = 10\nuint64.gt_lte_exclusive = 10\n"
+            "description": "uint64.gt = 10\nuint64.gt_lt = 10\nuint64.gt_lt_exclusive = 10\nuint64.gt_lte = 10\nuint64.gt_lte_exclusive = 10\nuint64.lt = 5\n"
           }
         },
         "title": "UInt64ExLTGT",
@@ -2920,7 +2920,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "uint64.lte = 256\nuint64.gte = 128\nuint64.gte_lt = 128\nuint64.gte_lt_exclusive = 128\nuint64.gte_lte = 128\nuint64.gte_lte_exclusive = 128\n"
+            "description": "uint64.gte = 128\nuint64.gte_lt = 128\nuint64.gte_lt_exclusive = 128\nuint64.gte_lte = 128\nuint64.gte_lte_exclusive = 128\nuint64.lte = 256\n"
           }
         },
         "title": "UInt64GTELTE",
@@ -2938,7 +2938,7 @@
             ],
             "title": "val",
             "format": "int64",
-            "description": "uint64.lt = 10\nuint64.gt = 5\nuint64.gt_lt = 5\nuint64.gt_lt_exclusive = 5\nuint64.gt_lte = 5\nuint64.gt_lte_exclusive = 5\n"
+            "description": "uint64.gt = 5\nuint64.gt_lt = 5\nuint64.gt_lt_exclusive = 5\nuint64.gt_lte = 5\nuint64.gt_lte_exclusive = 5\nuint64.lt = 10\n"
           }
         },
         "title": "UInt64GTLT",
@@ -2956,7 +2956,7 @@
             "maximum": 256,
             "minimum": 128,
             "format": "int64",
-            "description": "uint64.lte = 256\nuint64.gte = 128\nuint64.gte_lt = 128\nuint64.gte_lt_exclusive = 128\nuint64.gte_lte = 128\nuint64.gte_lte_exclusive = 128\n"
+            "description": "uint64.gte = 128\nuint64.gte_lt = 128\nuint64.gte_lt_exclusive = 128\nuint64.gte_lte = 128\nuint64.gte_lte_exclusive = 128\nuint64.lte = 256\n"
           }
         },
         "title": "UInt64Ignore",

--- a/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.numbers.openapi.yaml
@@ -270,12 +270,12 @@ components:
           maximum: 128
           minimum: 256
           description: |
-            fixed32.lte = 128
             fixed32.gte = 256
             fixed32.gte_lt = 256
             fixed32.gte_lt_exclusive = 256
             fixed32.gte_lte = 256
             fixed32.gte_lte_exclusive = 256
+            fixed32.lte = 128
       title: Fixed32ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Fixed32ExLTGT:
@@ -287,12 +287,12 @@ components:
           type: integer
           title: val
           description: |
-            fixed32.lt = 5
             fixed32.gt = 10
             fixed32.gt_lt = 10
             fixed32.gt_lt_exclusive = 10
             fixed32.gt_lte = 10
             fixed32.gt_lte_exclusive = 10
+            fixed32.lt = 5
       title: Fixed32ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.Fixed32Example:
@@ -346,12 +346,12 @@ components:
           maximum: 256
           minimum: 128
           description: |
-            fixed32.lte = 256
             fixed32.gte = 128
             fixed32.gte_lt = 128
             fixed32.gte_lt_exclusive = 128
             fixed32.gte_lte = 128
             fixed32.gte_lte_exclusive = 128
+            fixed32.lte = 256
       title: Fixed32GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Fixed32GTLT:
@@ -363,12 +363,12 @@ components:
           type: integer
           title: val
           description: |
-            fixed32.lt = 10
             fixed32.gt = 5
             fixed32.gt_lt = 5
             fixed32.gt_lt_exclusive = 5
             fixed32.gt_lte = 5
             fixed32.gt_lte_exclusive = 5
+            fixed32.lt = 10
       title: Fixed32GTLT
       additionalProperties: false
     buf.validate.conformance.cases.Fixed32Ignore:
@@ -380,12 +380,12 @@ components:
           maximum: 256
           minimum: 128
           description: |
-            fixed32.lte = 256
             fixed32.gte = 128
             fixed32.gte_lt = 128
             fixed32.gte_lt_exclusive = 128
             fixed32.gte_lte = 128
             fixed32.gte_lte_exclusive = 128
+            fixed32.lte = 256
       title: Fixed32Ignore
       additionalProperties: false
     buf.validate.conformance.cases.Fixed32In:
@@ -485,12 +485,12 @@ components:
           minimum: 256
           format: int64
           description: |
-            fixed64.lte = 128
             fixed64.gte = 256
             fixed64.gte_lt = 256
             fixed64.gte_lt_exclusive = 256
             fixed64.gte_lte = 256
             fixed64.gte_lte_exclusive = 256
+            fixed64.lte = 128
       title: Fixed64ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Fixed64ExLTGT:
@@ -505,12 +505,12 @@ components:
           title: val
           format: int64
           description: |
-            fixed64.lt = 5
             fixed64.gt = 10
             fixed64.gt_lt = 10
             fixed64.gt_lt_exclusive = 10
             fixed64.gt_lte = 10
             fixed64.gt_lte_exclusive = 10
+            fixed64.lt = 5
       title: Fixed64ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.Fixed64Example:
@@ -576,12 +576,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            fixed64.lte = 256
             fixed64.gte = 128
             fixed64.gte_lt = 128
             fixed64.gte_lt_exclusive = 128
             fixed64.gte_lte = 128
             fixed64.gte_lte_exclusive = 128
+            fixed64.lte = 256
       title: Fixed64GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Fixed64GTLT:
@@ -596,12 +596,12 @@ components:
           title: val
           format: int64
           description: |
-            fixed64.lt = 10
             fixed64.gt = 5
             fixed64.gt_lt = 5
             fixed64.gt_lt_exclusive = 5
             fixed64.gt_lte = 5
             fixed64.gt_lte_exclusive = 5
+            fixed64.lt = 10
       title: Fixed64GTLT
       additionalProperties: false
     buf.validate.conformance.cases.Fixed64Ignore:
@@ -616,12 +616,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            fixed64.lte = 256
             fixed64.gte = 128
             fixed64.gte_lt = 128
             fixed64.gte_lt_exclusive = 128
             fixed64.gte_lte = 128
             fixed64.gte_lte_exclusive = 128
+            fixed64.lte = 256
       title: Fixed64Ignore
       additionalProperties: false
     buf.validate.conformance.cases.Fixed64In:
@@ -967,12 +967,12 @@ components:
           minimum: 256
           format: int32
           description: |
-            int32.lte = 128
             int32.gte = 256
             int32.gte_lt = 256
             int32.gte_lt_exclusive = 256
             int32.gte_lte = 256
             int32.gte_lte_exclusive = 256
+            int32.lte = 128
       title: Int32ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Int32ExLTGT:
@@ -985,12 +985,12 @@ components:
           title: val
           format: int32
           description: |
-            int32.lt = 0
             int32.gt = 10
             int32.gt_lt = 10
             int32.gt_lt_exclusive = 10
             int32.gt_lte = 10
             int32.gt_lte_exclusive = 10
+            int32.lt = 0
       title: Int32ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.Int32Example:
@@ -1048,12 +1048,12 @@ components:
           minimum: 128
           format: int32
           description: |
-            int32.lte = 256
             int32.gte = 128
             int32.gte_lt = 128
             int32.gte_lt_exclusive = 128
             int32.gte_lte = 128
             int32.gte_lte_exclusive = 128
+            int32.lte = 256
       title: Int32GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Int32GTLT:
@@ -1066,12 +1066,12 @@ components:
           title: val
           format: int32
           description: |
-            int32.lt = 10
             int32.gt = 0
             int32.gt_lt = 0
             int32.gt_lt_exclusive = 0
             int32.gt_lte = 0
             int32.gt_lte_exclusive = 0
+            int32.lt = 10
       title: Int32GTLT
       additionalProperties: false
     buf.validate.conformance.cases.Int32Ignore:
@@ -1084,12 +1084,12 @@ components:
           minimum: 128
           format: int32
           description: |
-            int32.lte = 256
             int32.gte = 128
             int32.gte_lt = 128
             int32.gte_lt_exclusive = 128
             int32.gte_lte = 128
             int32.gte_lte_exclusive = 128
+            int32.lte = 256
       title: Int32Ignore
       additionalProperties: false
     buf.validate.conformance.cases.Int32In:
@@ -1333,12 +1333,12 @@ components:
           minimum: 256
           format: int64
           description: |
-            int64.lte = 128
             int64.gte = 256
             int64.gte_lt = 256
             int64.gte_lt_exclusive = 256
             int64.gte_lte = 256
             int64.gte_lte_exclusive = 256
+            int64.lte = 128
       title: Int64ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Int64ExLTGT:
@@ -1353,12 +1353,12 @@ components:
           title: val
           format: int64
           description: |
-            int64.lt = 0
             int64.gt = 10
             int64.gt_lt = 10
             int64.gt_lt_exclusive = 10
             int64.gt_lte = 10
             int64.gt_lte_exclusive = 10
+            int64.lt = 0
       title: Int64ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.Int64Example:
@@ -1424,12 +1424,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            int64.lte = 256
             int64.gte = 128
             int64.gte_lt = 128
             int64.gte_lt_exclusive = 128
             int64.gte_lte = 128
             int64.gte_lte_exclusive = 128
+            int64.lte = 256
       title: Int64GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.Int64GTLT:
@@ -1444,12 +1444,12 @@ components:
           title: val
           format: int64
           description: |
-            int64.lt = 10
             int64.gt = 0
             int64.gt_lt = 0
             int64.gt_lt_exclusive = 0
             int64.gt_lte = 0
             int64.gt_lte_exclusive = 0
+            int64.lt = 10
       title: Int64GTLT
       additionalProperties: false
     buf.validate.conformance.cases.Int64Ignore:
@@ -1464,12 +1464,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            int64.lte = 256
             int64.gte = 128
             int64.gte_lt = 128
             int64.gte_lt_exclusive = 128
             int64.gte_lte = 128
             int64.gte_lte_exclusive = 128
+            int64.lte = 256
       title: Int64Ignore
       additionalProperties: false
     buf.validate.conformance.cases.Int64In:
@@ -1600,12 +1600,12 @@ components:
           minimum: 256
           format: int32
           description: |
-            sfixed32.lte = 128
             sfixed32.gte = 256
             sfixed32.gte_lt = 256
             sfixed32.gte_lt_exclusive = 256
             sfixed32.gte_lte = 256
             sfixed32.gte_lte_exclusive = 256
+            sfixed32.lte = 128
       title: SFixed32ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SFixed32ExLTGT:
@@ -1618,12 +1618,12 @@ components:
           title: val
           format: int32
           description: |
-            sfixed32.lt = 0
             sfixed32.gt = 10
             sfixed32.gt_lt = 10
             sfixed32.gt_lt_exclusive = 10
             sfixed32.gt_lte = 10
             sfixed32.gt_lte_exclusive = 10
+            sfixed32.lt = 0
       title: SFixed32ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.SFixed32Example:
@@ -1681,12 +1681,12 @@ components:
           minimum: 128
           format: int32
           description: |
-            sfixed32.lte = 256
             sfixed32.gte = 128
             sfixed32.gte_lt = 128
             sfixed32.gte_lt_exclusive = 128
             sfixed32.gte_lte = 128
             sfixed32.gte_lte_exclusive = 128
+            sfixed32.lte = 256
       title: SFixed32GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SFixed32GTLT:
@@ -1699,12 +1699,12 @@ components:
           title: val
           format: int32
           description: |
-            sfixed32.lt = 10
             sfixed32.gt = 0
             sfixed32.gt_lt = 0
             sfixed32.gt_lt_exclusive = 0
             sfixed32.gt_lte = 0
             sfixed32.gt_lte_exclusive = 0
+            sfixed32.lt = 10
       title: SFixed32GTLT
       additionalProperties: false
     buf.validate.conformance.cases.SFixed32Ignore:
@@ -1717,12 +1717,12 @@ components:
           minimum: 128
           format: int32
           description: |
-            sfixed32.lte = 256
             sfixed32.gte = 128
             sfixed32.gte_lt = 128
             sfixed32.gte_lt_exclusive = 128
             sfixed32.gte_lte = 128
             sfixed32.gte_lte_exclusive = 128
+            sfixed32.lte = 256
       title: SFixed32Ignore
       additionalProperties: false
     buf.validate.conformance.cases.SFixed32In:
@@ -1828,12 +1828,12 @@ components:
           minimum: 256
           format: int64
           description: |
-            sfixed64.lte = 128
             sfixed64.gte = 256
             sfixed64.gte_lt = 256
             sfixed64.gte_lt_exclusive = 256
             sfixed64.gte_lte = 256
             sfixed64.gte_lte_exclusive = 256
+            sfixed64.lte = 128
       title: SFixed64ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SFixed64ExLTGT:
@@ -1848,12 +1848,12 @@ components:
           title: val
           format: int64
           description: |
-            sfixed64.lt = 0
             sfixed64.gt = 10
             sfixed64.gt_lt = 10
             sfixed64.gt_lt_exclusive = 10
             sfixed64.gt_lte = 10
             sfixed64.gt_lte_exclusive = 10
+            sfixed64.lt = 0
       title: SFixed64ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.SFixed64Example:
@@ -1919,12 +1919,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            sfixed64.lte = 256
             sfixed64.gte = 128
             sfixed64.gte_lt = 128
             sfixed64.gte_lt_exclusive = 128
             sfixed64.gte_lte = 128
             sfixed64.gte_lte_exclusive = 128
+            sfixed64.lte = 256
       title: SFixed64GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SFixed64GTLT:
@@ -1939,12 +1939,12 @@ components:
           title: val
           format: int64
           description: |
-            sfixed64.lt = 10
             sfixed64.gt = 0
             sfixed64.gt_lt = 0
             sfixed64.gt_lt_exclusive = 0
             sfixed64.gt_lte = 0
             sfixed64.gt_lte_exclusive = 0
+            sfixed64.lt = 10
       title: SFixed64GTLT
       additionalProperties: false
     buf.validate.conformance.cases.SFixed64Ignore:
@@ -1959,12 +1959,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            sfixed64.lte = 256
             sfixed64.gte = 128
             sfixed64.gte_lt = 128
             sfixed64.gte_lt_exclusive = 128
             sfixed64.gte_lte = 128
             sfixed64.gte_lte_exclusive = 128
+            sfixed64.lte = 256
       title: SFixed64Ignore
       additionalProperties: false
     buf.validate.conformance.cases.SFixed64In:
@@ -2080,12 +2080,12 @@ components:
           minimum: 256
           format: int32
           description: |
-            sint32.lte = 128
             sint32.gte = 256
             sint32.gte_lt = 256
             sint32.gte_lt_exclusive = 256
             sint32.gte_lte = 256
             sint32.gte_lte_exclusive = 256
+            sint32.lte = 128
       title: SInt32ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SInt32ExLTGT:
@@ -2098,12 +2098,12 @@ components:
           title: val
           format: int32
           description: |
-            sint32.lt = 0
             sint32.gt = 10
             sint32.gt_lt = 10
             sint32.gt_lt_exclusive = 10
             sint32.gt_lte = 10
             sint32.gt_lte_exclusive = 10
+            sint32.lt = 0
       title: SInt32ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.SInt32Example:
@@ -2161,12 +2161,12 @@ components:
           minimum: 128
           format: int32
           description: |
-            sint32.lte = 256
             sint32.gte = 128
             sint32.gte_lt = 128
             sint32.gte_lt_exclusive = 128
             sint32.gte_lte = 128
             sint32.gte_lte_exclusive = 128
+            sint32.lte = 256
       title: SInt32GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SInt32GTLT:
@@ -2179,12 +2179,12 @@ components:
           title: val
           format: int32
           description: |
-            sint32.lt = 10
             sint32.gt = 0
             sint32.gt_lt = 0
             sint32.gt_lt_exclusive = 0
             sint32.gt_lte = 0
             sint32.gt_lte_exclusive = 0
+            sint32.lt = 10
       title: SInt32GTLT
       additionalProperties: false
     buf.validate.conformance.cases.SInt32Ignore:
@@ -2197,12 +2197,12 @@ components:
           minimum: 128
           format: int32
           description: |
-            sint32.lte = 256
             sint32.gte = 128
             sint32.gte_lt = 128
             sint32.gte_lt_exclusive = 128
             sint32.gte_lte = 128
             sint32.gte_lte_exclusive = 128
+            sint32.lte = 256
       title: SInt32Ignore
       additionalProperties: false
     buf.validate.conformance.cases.SInt32In:
@@ -2308,12 +2308,12 @@ components:
           minimum: 256
           format: int64
           description: |
-            sint64.lte = 128
             sint64.gte = 256
             sint64.gte_lt = 256
             sint64.gte_lt_exclusive = 256
             sint64.gte_lte = 256
             sint64.gte_lte_exclusive = 256
+            sint64.lte = 128
       title: SInt64ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SInt64ExLTGT:
@@ -2328,12 +2328,12 @@ components:
           title: val
           format: int64
           description: |
-            sint64.lt = 0
             sint64.gt = 10
             sint64.gt_lt = 10
             sint64.gt_lt_exclusive = 10
             sint64.gt_lte = 10
             sint64.gt_lte_exclusive = 10
+            sint64.lt = 0
       title: SInt64ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.SInt64Example:
@@ -2399,12 +2399,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            sint64.lte = 256
             sint64.gte = 128
             sint64.gte_lt = 128
             sint64.gte_lt_exclusive = 128
             sint64.gte_lte = 128
             sint64.gte_lte_exclusive = 128
+            sint64.lte = 256
       title: SInt64GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.SInt64GTLT:
@@ -2419,12 +2419,12 @@ components:
           title: val
           format: int64
           description: |
-            sint64.lt = 10
             sint64.gt = 0
             sint64.gt_lt = 0
             sint64.gt_lt_exclusive = 0
             sint64.gt_lte = 0
             sint64.gt_lte_exclusive = 0
+            sint64.lt = 10
       title: SInt64GTLT
       additionalProperties: false
     buf.validate.conformance.cases.SInt64Ignore:
@@ -2439,12 +2439,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            sint64.lte = 256
             sint64.gte = 128
             sint64.gte_lt = 128
             sint64.gte_lt_exclusive = 128
             sint64.gte_lte = 128
             sint64.gte_lte_exclusive = 128
+            sint64.lte = 256
       title: SInt64Ignore
       additionalProperties: false
     buf.validate.conformance.cases.SInt64In:
@@ -2558,12 +2558,12 @@ components:
           maximum: 128
           minimum: 256
           description: |
-            uint32.lte = 128
             uint32.gte = 256
             uint32.gte_lt = 256
             uint32.gte_lt_exclusive = 256
             uint32.gte_lte = 256
             uint32.gte_lte_exclusive = 256
+            uint32.lte = 128
       title: UInt32ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.UInt32ExLTGT:
@@ -2575,12 +2575,12 @@ components:
           type: integer
           title: val
           description: |
-            uint32.lt = 5
             uint32.gt = 10
             uint32.gt_lt = 10
             uint32.gt_lt_exclusive = 10
             uint32.gt_lte = 10
             uint32.gt_lte_exclusive = 10
+            uint32.lt = 5
       title: UInt32ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.UInt32Example:
@@ -2634,12 +2634,12 @@ components:
           maximum: 256
           minimum: 128
           description: |
-            uint32.lte = 256
             uint32.gte = 128
             uint32.gte_lt = 128
             uint32.gte_lt_exclusive = 128
             uint32.gte_lte = 128
             uint32.gte_lte_exclusive = 128
+            uint32.lte = 256
       title: UInt32GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.UInt32GTLT:
@@ -2651,12 +2651,12 @@ components:
           type: integer
           title: val
           description: |
-            uint32.lt = 10
             uint32.gt = 5
             uint32.gt_lt = 5
             uint32.gt_lt_exclusive = 5
             uint32.gt_lte = 5
             uint32.gt_lte_exclusive = 5
+            uint32.lt = 10
       title: UInt32GTLT
       additionalProperties: false
     buf.validate.conformance.cases.UInt32Ignore:
@@ -2668,12 +2668,12 @@ components:
           maximum: 256
           minimum: 128
           description: |
-            uint32.lte = 256
             uint32.gte = 128
             uint32.gte_lt = 128
             uint32.gte_lt_exclusive = 128
             uint32.gte_lte = 128
             uint32.gte_lte_exclusive = 128
+            uint32.lte = 256
       title: UInt32Ignore
       additionalProperties: false
     buf.validate.conformance.cases.UInt32In:
@@ -2773,12 +2773,12 @@ components:
           minimum: 256
           format: int64
           description: |
-            uint64.lte = 128
             uint64.gte = 256
             uint64.gte_lt = 256
             uint64.gte_lt_exclusive = 256
             uint64.gte_lte = 256
             uint64.gte_lte_exclusive = 256
+            uint64.lte = 128
       title: UInt64ExGTELTE
       additionalProperties: false
     buf.validate.conformance.cases.UInt64ExLTGT:
@@ -2793,12 +2793,12 @@ components:
           title: val
           format: int64
           description: |
-            uint64.lt = 5
             uint64.gt = 10
             uint64.gt_lt = 10
             uint64.gt_lt_exclusive = 10
             uint64.gt_lte = 10
             uint64.gt_lte_exclusive = 10
+            uint64.lt = 5
       title: UInt64ExLTGT
       additionalProperties: false
     buf.validate.conformance.cases.UInt64Example:
@@ -2864,12 +2864,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            uint64.lte = 256
             uint64.gte = 128
             uint64.gte_lt = 128
             uint64.gte_lt_exclusive = 128
             uint64.gte_lte = 128
             uint64.gte_lte_exclusive = 128
+            uint64.lte = 256
       title: UInt64GTELTE
       additionalProperties: false
     buf.validate.conformance.cases.UInt64GTLT:
@@ -2884,12 +2884,12 @@ components:
           title: val
           format: int64
           description: |
-            uint64.lt = 10
             uint64.gt = 5
             uint64.gt_lt = 5
             uint64.gt_lt_exclusive = 5
             uint64.gt_lte = 5
             uint64.gt_lte_exclusive = 5
+            uint64.lt = 10
       title: UInt64GTLT
       additionalProperties: false
     buf.validate.conformance.cases.UInt64Ignore:
@@ -2904,12 +2904,12 @@ components:
           minimum: 128
           format: int64
           description: |
-            uint64.lte = 256
             uint64.gte = 128
             uint64.gte_lt = 128
             uint64.gte_lt_exclusive = 128
             uint64.gte_lte = 128
             uint64.gte_lte_exclusive = 128
+            uint64.lte = 256
       title: UInt64Ignore
       additionalProperties: false
     buf.validate.conformance.cases.UInt64In:

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.json
@@ -510,7 +510,7 @@
             "title": "int32_bounds",
             "minimum": 5,
             "format": "int32",
-            "description": "int32.lt = 10\nint32.gte = 5\nint32.gte_lt = 5\nint32.gte_lt_exclusive = 5\nint32.gte_lte = 5\nint32.gte_lte_exclusive = 5\n"
+            "description": "int32.gte = 5\nint32.gte_lt = 5\nint32.gte_lt_exclusive = 5\nint32.gte_lte = 5\nint32.gte_lte_exclusive = 5\nint32.lt = 10\n"
           },
           "int64Const": {
             "type": [
@@ -611,7 +611,7 @@
             "title": "int64_bounds",
             "minimum": 5,
             "format": "int64",
-            "description": "int64.lt = 10\nint64.gte = 5\nint64.gte_lt = 5\nint64.gte_lt_exclusive = 5\nint64.gte_lte = 5\nint64.gte_lte_exclusive = 5\n"
+            "description": "int64.gte = 5\nint64.gte_lt = 5\nint64.gte_lt_exclusive = 5\nint64.gte_lte = 5\nint64.gte_lte_exclusive = 5\nint64.lt = 10\n"
           },
           "uint32Const": {
             "type": "integer",
@@ -677,7 +677,7 @@
             "type": "integer",
             "title": "uint32_bounds",
             "minimum": 5,
-            "description": "uint32.lt = 10\nuint32.gte = 5\nuint32.gte_lt = 5\nuint32.gte_lt_exclusive = 5\nuint32.gte_lte = 5\nuint32.gte_lte_exclusive = 5\n"
+            "description": "uint32.gte = 5\nuint32.gte_lt = 5\nuint32.gte_lt_exclusive = 5\nuint32.gte_lte = 5\nuint32.gte_lte_exclusive = 5\nuint32.lt = 10\n"
           },
           "uint64Const": {
             "type": [
@@ -778,7 +778,7 @@
             "title": "uint64_bounds",
             "minimum": 5,
             "format": "int64",
-            "description": "uint64.lt = 10\nuint64.gte = 5\nuint64.gte_lt = 5\nuint64.gte_lt_exclusive = 5\nuint64.gte_lte = 5\nuint64.gte_lte_exclusive = 5\n"
+            "description": "uint64.gte = 5\nuint64.gte_lt = 5\nuint64.gte_lt_exclusive = 5\nuint64.gte_lte = 5\nuint64.gte_lte_exclusive = 5\nuint64.lt = 10\n"
           },
           "sint32Const": {
             "type": "integer",
@@ -852,7 +852,7 @@
             "title": "sint32_bounds",
             "minimum": 5,
             "format": "int32",
-            "description": "sint32.lt = 10\nsint32.gte = 5\nsint32.gte_lt = 5\nsint32.gte_lt_exclusive = 5\nsint32.gte_lte = 5\nsint32.gte_lte_exclusive = 5\n"
+            "description": "sint32.gte = 5\nsint32.gte_lt = 5\nsint32.gte_lt_exclusive = 5\nsint32.gte_lte = 5\nsint32.gte_lte_exclusive = 5\nsint32.lt = 10\n"
           },
           "sint64Const": {
             "type": [
@@ -953,7 +953,7 @@
             "title": "sint64_bounds",
             "minimum": 5,
             "format": "int64",
-            "description": "sint64.lt = 10\nsint64.gte = 5\nsint64.gte_lt = 5\nsint64.gte_lt_exclusive = 5\nsint64.gte_lte = 5\nsint64.gte_lte_exclusive = 5\n"
+            "description": "sint64.gte = 5\nsint64.gte_lt = 5\nsint64.gte_lt_exclusive = 5\nsint64.gte_lte = 5\nsint64.gte_lte_exclusive = 5\nsint64.lt = 10\n"
           },
           "fixed32Const": {
             "type": "integer",
@@ -1019,7 +1019,7 @@
             "type": "integer",
             "title": "fixed32_bounds",
             "minimum": 5,
-            "description": "fixed32.lt = 10\nfixed32.gte = 5\nfixed32.gte_lt = 5\nfixed32.gte_lt_exclusive = 5\nfixed32.gte_lte = 5\nfixed32.gte_lte_exclusive = 5\n"
+            "description": "fixed32.gte = 5\nfixed32.gte_lt = 5\nfixed32.gte_lt_exclusive = 5\nfixed32.gte_lte = 5\nfixed32.gte_lte_exclusive = 5\nfixed32.lt = 10\n"
           },
           "fixed64Const": {
             "type": [
@@ -1120,7 +1120,7 @@
             "title": "fixed64_bounds",
             "minimum": 5,
             "format": "int64",
-            "description": "fixed64.lt = 10\nfixed64.gte = 5\nfixed64.gte_lt = 5\nfixed64.gte_lt_exclusive = 5\nfixed64.gte_lte = 5\nfixed64.gte_lte_exclusive = 5\n"
+            "description": "fixed64.gte = 5\nfixed64.gte_lt = 5\nfixed64.gte_lt_exclusive = 5\nfixed64.gte_lte = 5\nfixed64.gte_lte_exclusive = 5\nfixed64.lt = 10\n"
           },
           "sfixed32Const": {
             "type": "integer",
@@ -1194,7 +1194,7 @@
             "title": "sfixed32_bounds",
             "minimum": 5,
             "format": "int32",
-            "description": "sfixed32.lt = 10\nsfixed32.gte = 5\nsfixed32.gte_lt = 5\nsfixed32.gte_lt_exclusive = 5\nsfixed32.gte_lte = 5\nsfixed32.gte_lte_exclusive = 5\n"
+            "description": "sfixed32.gte = 5\nsfixed32.gte_lt = 5\nsfixed32.gte_lt_exclusive = 5\nsfixed32.gte_lte = 5\nsfixed32.gte_lte_exclusive = 5\nsfixed32.lt = 10\n"
           },
           "sfixed64Const": {
             "type": [
@@ -1295,7 +1295,7 @@
             "title": "sfixed64_bounds",
             "minimum": 5,
             "format": "int64",
-            "description": "sfixed64.lt = 10\nsfixed64.gte = 5\nsfixed64.gte_lt = 5\nsfixed64.gte_lt_exclusive = 5\nsfixed64.gte_lte = 5\nsfixed64.gte_lte_exclusive = 5\n"
+            "description": "sfixed64.gte = 5\nsfixed64.gte_lt = 5\nsfixed64.gte_lt_exclusive = 5\nsfixed64.gte_lte = 5\nsfixed64.gte_lte_exclusive = 5\nsfixed64.lt = 10\n"
           },
           "stringConst": {
             "type": "string",
@@ -1655,7 +1655,7 @@
               "type": "string",
               "maxLength": 10,
               "minLength": 3,
-              "description": "string.min_len = 3\nstring.max_len = 10\n"
+              "description": "string.max_len = 10\nstring.min_len = 3\n"
             },
             "title": "repeated_items"
           },
@@ -1693,7 +1693,7 @@
               "title": "value",
               "maxLength": 20,
               "minLength": 5,
-              "description": "string.min_len = 5\nstring.max_len = 20\n"
+              "description": "string.max_len = 20\nstring.min_len = 5\n"
             }
           },
           "anyIn": {
@@ -1764,7 +1764,7 @@
           },
           "durationRange": {
             "title": "duration_range",
-            "description": "duration.lt = 10s\nduration.gt = 5s\nduration.gt_lt = 5s\nduration.gt_lt_exclusive = 5s\nduration.gt_lte = 5s\nduration.gt_lte_exclusive = 5s\n",
+            "description": "duration.gt = 5s\nduration.gt_lt = 5s\nduration.gt_lt_exclusive = 5s\nduration.gt_lte = 5s\nduration.gt_lte_exclusive = 5s\nduration.lt = 10s\n",
             "$ref": "#/components/schemas/google.protobuf.Duration"
           },
           "durationGte": {
@@ -1805,7 +1805,7 @@
           },
           "timestampRange": {
             "title": "timestamp_range",
-            "description": "timestamp.lt = 2023-01-01T00:00:00Z\ntimestamp.gt = 2022-12-31T00:00:00Z\ntimestamp.gt_lt = 2022-12-31T00:00:00Z\ntimestamp.gt_lt_exclusive = 2022-12-31T00:00:00Z\ntimestamp.gt_lte = 2022-12-31T00:00:00Z\ntimestamp.gt_lte_exclusive = 2022-12-31T00:00:00Z\n",
+            "description": "timestamp.gt = 2022-12-31T00:00:00Z\ntimestamp.gt_lt = 2022-12-31T00:00:00Z\ntimestamp.gt_lt_exclusive = 2022-12-31T00:00:00Z\ntimestamp.gt_lte = 2022-12-31T00:00:00Z\ntimestamp.gt_lte_exclusive = 2022-12-31T00:00:00Z\ntimestamp.lt = 2023-01-01T00:00:00Z\n",
             "$ref": "#/components/schemas/google.protobuf.Timestamp"
           },
           "timestampLtNow": {

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
@@ -595,12 +595,12 @@ components:
           minimum: 5
           format: int32
           description: |
-            int32.lt = 10
             int32.gte = 5
             int32.gte_lt = 5
             int32.gte_lt_exclusive = 5
             int32.gte_lte = 5
             int32.gte_lte_exclusive = 5
+            int32.lt = 10
         int64Const:
           type:
             - integer
@@ -696,12 +696,12 @@ components:
           minimum: 5
           format: int64
           description: |
-            int64.lt = 10
             int64.gte = 5
             int64.gte_lt = 5
             int64.gte_lt_exclusive = 5
             int64.gte_lte = 5
             int64.gte_lte_exclusive = 5
+            int64.lt = 10
         uint32Const:
           type: integer
           title: uint32_const
@@ -771,12 +771,12 @@ components:
           title: uint32_bounds
           minimum: 5
           description: |
-            uint32.lt = 10
             uint32.gte = 5
             uint32.gte_lt = 5
             uint32.gte_lt_exclusive = 5
             uint32.gte_lte = 5
             uint32.gte_lte_exclusive = 5
+            uint32.lt = 10
         uint64Const:
           type:
             - integer
@@ -872,12 +872,12 @@ components:
           minimum: 5
           format: int64
           description: |
-            uint64.lt = 10
             uint64.gte = 5
             uint64.gte_lt = 5
             uint64.gte_lt_exclusive = 5
             uint64.gte_lte = 5
             uint64.gte_lte_exclusive = 5
+            uint64.lt = 10
         sint32Const:
           type: integer
           title: sint32_const
@@ -955,12 +955,12 @@ components:
           minimum: 5
           format: int32
           description: |
-            sint32.lt = 10
             sint32.gte = 5
             sint32.gte_lt = 5
             sint32.gte_lt_exclusive = 5
             sint32.gte_lte = 5
             sint32.gte_lte_exclusive = 5
+            sint32.lt = 10
         sint64Const:
           type:
             - integer
@@ -1056,12 +1056,12 @@ components:
           minimum: 5
           format: int64
           description: |
-            sint64.lt = 10
             sint64.gte = 5
             sint64.gte_lt = 5
             sint64.gte_lt_exclusive = 5
             sint64.gte_lte = 5
             sint64.gte_lte_exclusive = 5
+            sint64.lt = 10
         fixed32Const:
           type: integer
           title: fixed32_const
@@ -1131,12 +1131,12 @@ components:
           title: fixed32_bounds
           minimum: 5
           description: |
-            fixed32.lt = 10
             fixed32.gte = 5
             fixed32.gte_lt = 5
             fixed32.gte_lt_exclusive = 5
             fixed32.gte_lte = 5
             fixed32.gte_lte_exclusive = 5
+            fixed32.lt = 10
         fixed64Const:
           type:
             - integer
@@ -1232,12 +1232,12 @@ components:
           minimum: 5
           format: int64
           description: |
-            fixed64.lt = 10
             fixed64.gte = 5
             fixed64.gte_lt = 5
             fixed64.gte_lt_exclusive = 5
             fixed64.gte_lte = 5
             fixed64.gte_lte_exclusive = 5
+            fixed64.lt = 10
         sfixed32Const:
           type: integer
           title: sfixed32_const
@@ -1315,12 +1315,12 @@ components:
           minimum: 5
           format: int32
           description: |
-            sfixed32.lt = 10
             sfixed32.gte = 5
             sfixed32.gte_lt = 5
             sfixed32.gte_lt_exclusive = 5
             sfixed32.gte_lte = 5
             sfixed32.gte_lte_exclusive = 5
+            sfixed32.lt = 10
         sfixed64Const:
           type:
             - integer
@@ -1416,12 +1416,12 @@ components:
           minimum: 5
           format: int64
           description: |
-            sfixed64.lt = 10
             sfixed64.gte = 5
             sfixed64.gte_lt = 5
             sfixed64.gte_lt_exclusive = 5
             sfixed64.gte_lte = 5
             sfixed64.gte_lte_exclusive = 5
+            sfixed64.lt = 10
         stringConst:
           type: string
           title: string_const
@@ -1786,8 +1786,8 @@ components:
             maxLength: 10
             minLength: 3
             description: |
-              string.min_len = 3
               string.max_len = 10
+              string.min_len = 3
           title: repeated_items
         mapMinPairs:
           type: object
@@ -1818,8 +1818,8 @@ components:
             maxLength: 20
             minLength: 5
             description: |
-              string.min_len = 5
               string.max_len = 20
+              string.min_len = 5
         anyIn:
           title: any_in
           enum:
@@ -1885,12 +1885,12 @@ components:
         durationRange:
           title: duration_range
           description: |
-            duration.lt = 10s
             duration.gt = 5s
             duration.gt_lt = 5s
             duration.gt_lt_exclusive = 5s
             duration.gt_lte = 5s
             duration.gt_lte_exclusive = 5s
+            duration.lt = 10s
           $ref: '#/components/schemas/google.protobuf.Duration'
         durationGte:
           title: duration_gte
@@ -1944,12 +1944,12 @@ components:
         timestampRange:
           title: timestamp_range
           description: |
-            timestamp.lt = 2023-01-01T00:00:00Z
             timestamp.gt = 2022-12-31T00:00:00Z
             timestamp.gt_lt = 2022-12-31T00:00:00Z
             timestamp.gt_lt_exclusive = 2022-12-31T00:00:00Z
             timestamp.gt_lte = 2022-12-31T00:00:00Z
             timestamp.gt_lte_exclusive = 2022-12-31T00:00:00Z
+            timestamp.lt = 2023-01-01T00:00:00Z
           $ref: '#/components/schemas/google.protobuf.Timestamp'
         timestampLtNow:
           title: timestamp_lt_now

--- a/internal/converter/testdata/standard/output/protovalidate.strings.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.strings.openapi.json
@@ -63,7 +63,7 @@
           "val": {
             "type": "string",
             "title": "val",
-            "description": "string.min_bytes = 4\nstring.max_bytes = 4\n"
+            "description": "string.max_bytes = 4\nstring.min_bytes = 4\n"
           }
         },
         "title": "StringEqualMinMaxBytes",
@@ -77,7 +77,7 @@
             "title": "val",
             "maxLength": 5,
             "minLength": 5,
-            "description": "string.min_len = 5\nstring.max_len = 5\n"
+            "description": "string.max_len = 5\nstring.min_len = 5\n"
           }
         },
         "title": "StringEqualMinMaxLen",
@@ -416,7 +416,7 @@
           "val": {
             "type": "string",
             "title": "val",
-            "description": "string.min_bytes = 4\nstring.max_bytes = 8\n"
+            "description": "string.max_bytes = 8\nstring.min_bytes = 4\n"
           }
         },
         "title": "StringMinMaxBytes",
@@ -430,7 +430,7 @@
             "title": "val",
             "maxLength": 5,
             "minLength": 3,
-            "description": "string.min_len = 3\nstring.max_len = 5\n"
+            "description": "string.max_len = 5\nstring.min_len = 3\n"
           }
         },
         "title": "StringMinMaxLen",

--- a/internal/converter/testdata/standard/output/protovalidate.strings.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.strings.openapi.yaml
@@ -56,8 +56,8 @@ components:
           type: string
           title: val
           description: |
-            string.min_bytes = 4
             string.max_bytes = 4
+            string.min_bytes = 4
       title: StringEqualMinMaxBytes
       additionalProperties: false
     buf.validate.conformance.cases.StringEqualMinMaxLen:
@@ -69,8 +69,8 @@ components:
           maxLength: 5
           minLength: 5
           description: |
-            string.min_len = 5
             string.max_len = 5
+            string.min_len = 5
       title: StringEqualMinMaxLen
       additionalProperties: false
     buf.validate.conformance.cases.StringExample:
@@ -369,8 +369,8 @@ components:
           type: string
           title: val
           description: |
-            string.min_bytes = 4
             string.max_bytes = 8
+            string.min_bytes = 4
       title: StringMinMaxBytes
       additionalProperties: false
     buf.validate.conformance.cases.StringMinMaxLen:
@@ -382,8 +382,8 @@ components:
           maxLength: 5
           minLength: 3
           description: |
-            string.min_len = 3
             string.max_len = 5
+            string.min_len = 3
       title: StringMinMaxLen
       additionalProperties: false
     buf.validate.conformance.cases.StringNone:

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.json
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.json
@@ -10,7 +10,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "CreateSession",
+        "summary": "Creates a session.",
         "description": "Creates a session.",
         "operationId": "tensorflowtest.MasterService.CreateSession",
         "parameters": [
@@ -69,7 +69,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "ExtendSession",
+        "summary": "Extends a session.",
         "description": "Extends a session.",
         "operationId": "tensorflowtest.MasterService.ExtendSession",
         "parameters": [
@@ -128,7 +128,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "PartialRunSetup",
+        "summary": "Prepares future partial run calls.",
         "description": "Prepares future partial run calls.",
         "operationId": "tensorflowtest.MasterService.PartialRunSetup",
         "parameters": [
@@ -187,7 +187,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "RunStep",
+        "summary": "Drives the graph computation.",
         "description": "Drives the graph computation.",
         "operationId": "tensorflowtest.MasterService.RunStep",
         "parameters": [
@@ -246,7 +246,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "CloseSession",
+        "summary": "Closes a session.",
         "description": "Closes a session.",
         "operationId": "tensorflowtest.MasterService.CloseSession",
         "parameters": [
@@ -305,7 +305,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "ListDevices",
+        "summary": "List the devices usable by the master.",
         "description": "List the devices usable by the master.",
         "operationId": "tensorflowtest.MasterService.ListDevices",
         "parameters": [
@@ -364,7 +364,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "Reset",
+        "summary": "Close and abandon all existing sessions.  Ongoing computations  will no longer affect fresh ones via the resources in containers listed in  the ResetRequest.  See ResetRequest for more details.",
         "description": "Close and abandon all existing sessions.  Ongoing computations\n will no longer affect fresh ones via the resources in containers listed in\n the ResetRequest.  See ResetRequest for more details.",
         "operationId": "tensorflowtest.MasterService.Reset",
         "parameters": [
@@ -423,7 +423,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "MakeCallable",
+        "summary": "Registers a callable for execution with RunCallable.",
         "description": "Registers a callable for execution with RunCallable.",
         "operationId": "tensorflowtest.MasterService.MakeCallable",
         "parameters": [
@@ -482,7 +482,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "RunCallable",
+        "summary": "Executes a callable registered with MakeCallable.",
         "description": "Executes a callable registered with MakeCallable.",
         "operationId": "tensorflowtest.MasterService.RunCallable",
         "parameters": [
@@ -541,7 +541,7 @@
         "tags": [
           "tensorflowtest.MasterService"
         ],
-        "summary": "ReleaseCallable",
+        "summary": "Frees resources associated with a callable registered with MakeCallable.",
         "description": "Frees resources associated with a callable registered with MakeCallable.",
         "operationId": "tensorflowtest.MasterService.ReleaseCallable",
         "parameters": [

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
@@ -7,7 +7,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: CreateSession
+      summary: Creates a session.
       description: Creates a session.
       operationId: tensorflowtest.MasterService.CreateSession
       parameters:
@@ -43,7 +43,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: ExtendSession
+      summary: Extends a session.
       description: Extends a session.
       operationId: tensorflowtest.MasterService.ExtendSession
       parameters:
@@ -79,7 +79,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: PartialRunSetup
+      summary: Prepares future partial run calls.
       description: Prepares future partial run calls.
       operationId: tensorflowtest.MasterService.PartialRunSetup
       parameters:
@@ -115,7 +115,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: RunStep
+      summary: Drives the graph computation.
       description: Drives the graph computation.
       operationId: tensorflowtest.MasterService.RunStep
       parameters:
@@ -151,7 +151,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: CloseSession
+      summary: Closes a session.
       description: Closes a session.
       operationId: tensorflowtest.MasterService.CloseSession
       parameters:
@@ -187,7 +187,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: ListDevices
+      summary: List the devices usable by the master.
       description: List the devices usable by the master.
       operationId: tensorflowtest.MasterService.ListDevices
       parameters:
@@ -223,7 +223,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: Reset
+      summary: Close and abandon all existing sessions.  Ongoing computations  will no longer affect fresh ones via the resources in containers listed in  the ResetRequest.  See ResetRequest for more details.
       description: |-
         Close and abandon all existing sessions.  Ongoing computations
          will no longer affect fresh ones via the resources in containers listed in
@@ -262,7 +262,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: MakeCallable
+      summary: Registers a callable for execution with RunCallable.
       description: Registers a callable for execution with RunCallable.
       operationId: tensorflowtest.MasterService.MakeCallable
       parameters:
@@ -298,7 +298,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: RunCallable
+      summary: Executes a callable registered with MakeCallable.
       description: Executes a callable registered with MakeCallable.
       operationId: tensorflowtest.MasterService.RunCallable
       parameters:
@@ -334,7 +334,7 @@ paths:
     post:
       tags:
         - tensorflowtest.MasterService
-      summary: ReleaseCallable
+      summary: Frees resources associated with a callable registered with MakeCallable.
       description: Frees resources associated with a callable registered with MakeCallable.
       operationId: tensorflowtest.MasterService.ReleaseCallable
       parameters:

--- a/internal/converter/testdata/trim_unused_type/output/has_unused.openapi.json
+++ b/internal/converter/testdata/trim_unused_type/output/has_unused.openapi.json
@@ -9,7 +9,7 @@
         "tags": [
           "has_unused_types.FlexService"
         ],
-        "summary": "NormalRPC",
+        "summary": "Normal RPC method",
         "description": "Normal RPC method",
         "operationId": "has_unused_types.FlexService.NormalRPC",
         "parameters": [

--- a/internal/converter/testdata/trim_unused_type/output/has_unused.openapi.yaml
+++ b/internal/converter/testdata/trim_unused_type/output/has_unused.openapi.yaml
@@ -6,7 +6,7 @@ paths:
     post:
       tags:
         - has_unused_types.FlexService
-      summary: NormalRPC
+      summary: Normal RPC method
       description: Normal RPC method
       operationId: has_unused_types.FlexService.NormalRPC
       parameters:

--- a/internal/converter/util/util.go
+++ b/internal/converter/util/util.go
@@ -76,6 +76,40 @@ func FormatComments(loc protoreflect.SourceLocation) string {
 	return strings.TrimSpace(builder.String())
 }
 
+func FormatOperationComments(loc protoreflect.SourceLocation) (summary string, description string) {
+	var leadingComments = strings.TrimSpace(loc.LeadingComments)
+	var trailingComments = strings.TrimSpace(loc.TrailingComments)
+
+	if leadingComments == "" && trailingComments == "" {
+		return "", ""
+	}
+
+	// Split leading comments by double newline to separate blocks
+	blocks := strings.Split(leadingComments, "\n\n")
+
+	// The first block is the summary
+	summary = strings.ReplaceAll(strings.TrimSpace(blocks[0]), "\n", " ") // Summary should be single line, replace newlines with spaces
+
+	// The rest of the blocks form the description
+	if len(blocks) > 1 {
+		description = strings.Join(blocks[1:], "\n\n")
+		description = strings.TrimSpace(description)
+	} else {
+		// If there's only one block, it serves as both summary and description
+		description = strings.TrimSpace(blocks[0])
+	}
+
+	// Append trailing comments to the description
+	if trailingComments != "" {
+		if description != "" {
+			description += "\n\n" // Add a blank line if description already exists
+		}
+		description += trailingComments
+	}
+
+	return summary, description
+}
+
 func BoolPtr(b bool) *bool {
 	return &b
 }

--- a/internal/converter/util/util.go
+++ b/internal/converter/util/util.go
@@ -88,7 +88,7 @@ func FormatOperationComments(loc protoreflect.SourceLocation) (summary string, d
 	blocks := strings.Split(leadingComments, "\n\n")
 
 	// The first block is the summary
-	summary = strings.ReplaceAll(strings.TrimSpace(blocks[0]), "\n", " ") // Summary should be single line, replace newlines with spaces
+	summary = strings.ReplaceAll(strings.TrimSpace(blocks[0]), "\n", " ")
 
 	// The rest of the blocks form the description
 	if len(blocks) > 1 {


### PR DESCRIPTION
Resolves #97 

Also fixes an issue where CEL expresses in descriptions can appear in a different order, causing un-needed diffs