### PR TITLE
feat: set required=false on parameters with OPTIONAL field behavior

### DIFF
--- a/internal/converter/googleapi/paths.go
+++ b/internal/converter/googleapi/paths.go
@@ -548,11 +548,14 @@ func flattenToParams(opts options.Options, md protoreflect.MessageDescriptor, pr
 
 					if !isComplex {
 						loc := field.ParentFile().SourceLocations().ByDescriptor(field)
+						// Check field behavior for required status
+						required := IsFieldRequired(field)
 						params = append(params, &v3.Parameter{
 							Name:        paramName,
 							In:          "query",
 							Description: util.FormatComments(loc),
 							Schema:      base.CreateSchemaProxy(wk.Schema),
+							Required:    required,
 						})
 						continue
 					}
@@ -563,7 +566,10 @@ func flattenToParams(opts options.Options, md protoreflect.MessageDescriptor, pr
 			parent := &base.Schema{}
 			schema := schema.FieldToSchema(opts, base.CreateSchemaProxy(parent), field)
 			var required *bool
-			if len(parent.Required) > 0 {
+			// First check field behavior annotations
+			required = IsFieldRequired(field)
+			// If no field behavior, check if field is in parent's required list
+			if required == nil && len(parent.Required) > 0 {
 				required = util.BoolPtr(true)
 			}
 			loc := field.ParentFile().SourceLocations().ByDescriptor(field)

--- a/internal/converter/testdata/standard/output/field_behavior.openapi.json
+++ b/internal/converter/testdata/standard/output/field_behavior.openapi.json
@@ -46,6 +46,7 @@
           {
             "name": "nickName",
             "in": "query",
+            "required": false,
             "schema": {
               "type": "string",
               "title": "nick_name",

--- a/internal/converter/testdata/standard/output/field_behavior.openapi.yaml
+++ b/internal/converter/testdata/standard/output/field_behavior.openapi.yaml
@@ -33,6 +33,7 @@ paths:
             writeOnly: true
         - name: nickName
           in: query
+          required: false
           schema:
             type: string
             title: nick_name


### PR DESCRIPTION
Add support for google.api.field_behavior annotations when generating OpenAPI parameters. Parameters mapped from proto fields with OPTIONAL behavior now explicitly set `required: false`, while fields with REQUIRED behavior set `required: true`.

The IsFieldRequired helper function evaluates all field behaviors on a field, with REQUIRED taking precedence over OPTIONAL when both are present. This ensures correct parameter requirements in the generated OpenAPI specification.

Changes:
- Add IsFieldRequired function to check field behavior annotations
- Update query parameter generation to respect field behaviors
- Update test expectations for field_behavior test case