### PR TITLE
fix(schema): keep oneof validation out of rendered variants

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -78,6 +78,7 @@ var scenarios = []Scenario{
 	{Name: "with_specification_extensions", Options: "base=testdata/with_specification_extensions/base.yaml,trim-unused-types"},
 	{Name: "additional_bindings"},
 	{Name: "path_params"},
+	{Name: "oneof_rendering", Options: "features=google.api.http;gnostic;protovalidate,with-proto-names"},
 	{Name: "with_override", Options: "override=testdata/with_override/override.yaml"},
 	{Name: "with_service_filters", Options: "services=**.User*"},
 	{Name: "with_google_error_detail", Options: "with-google-error-detail"},
@@ -184,6 +185,10 @@ func validateOpenAPISpec(t *testing.T, protofile string, spec string) {
 			testCase.Errors = []string{}
 		}
 		t.Run(testCase.Name, func(tt *testing.T) {
+			if len(testCase.VariantTitles) > 0 {
+				assertRequestVariantTitles(tt, spec, testCase)
+			}
+
 			var body io.Reader
 			if len(testCase.Body) > 0 {
 				body = strings.NewReader(testCase.Body)
@@ -207,6 +212,68 @@ func validateOpenAPISpec(t *testing.T, protofile string, spec string) {
 			assert.Equal(tt, ok, len(testCase.Errors) == 0)
 		})
 	}
+}
+
+func assertRequestVariantTitles(t *testing.T, spec string, testCase TestCase) {
+	t.Helper()
+
+	document := map[string]any{}
+	require.NoError(t, yaml.Unmarshal([]byte(spec), &document))
+
+	schemaPath := testCase.Path
+	if testCase.SchemaPath != "" {
+		schemaPath = testCase.SchemaPath
+	}
+	schema := nestedMap(
+		t,
+		document,
+		"paths",
+		schemaPath,
+		strings.ToLower(testCase.Method),
+		"requestBody",
+		"content",
+		"application/json",
+		"schema",
+	)
+	if ref, ok := schema["$ref"].(string); ok {
+		const componentPrefix = "#/components/schemas/"
+		require.True(t, strings.HasPrefix(ref, componentPrefix))
+		schema = nestedMap(t, document, "components", "schemas", strings.TrimPrefix(ref, componentPrefix))
+	}
+
+	variantsValue, ok := schema["oneOf"]
+	if !ok {
+		variantsValue, ok = schema["anyOf"]
+	}
+	require.True(t, ok, "request schema has no oneOf or anyOf variants")
+
+	variants, ok := variantsValue.([]any)
+	require.True(t, ok)
+	titles := make([]string, 0, len(variants))
+	for _, variantValue := range variants {
+		variant, ok := variantValue.(map[string]any)
+		require.True(t, ok)
+		title, ok := variant["title"].(string)
+		require.True(t, ok, "variant has no title: %#v", variant)
+		properties, ok := variant["properties"].(map[string]any)
+		require.True(t, ok, "variant has no properties: %#v", variant)
+		require.NotEmpty(t, properties)
+		titles = append(titles, title)
+	}
+	assert.Equal(t, testCase.VariantTitles, titles)
+}
+
+func nestedMap(t *testing.T, root map[string]any, keys ...string) map[string]any {
+	t.Helper()
+
+	current := root
+	for _, key := range keys {
+		value, ok := current[key]
+		require.True(t, ok, "missing schema path element %q", key)
+		current, ok = value.(map[string]any)
+		require.True(t, ok, "schema path element %q is not an object", key)
+	}
+	return current
 }
 
 // TestConvert uses data in testdata/ to make requests to generate openapi documents,
@@ -373,13 +440,15 @@ type TestCaseFile struct {
 }
 
 type TestCase struct {
-	Name    string            `yaml:"name"`
-	Method  string            `yaml:"method"`
-	Path    string            `yaml:"path"`
-	Headers map[string]string `yaml:"headers"`
-	Body    string            `yaml:"body"`
-	Query   string            `yaml:"query"`
-	Errors  []string          `yaml:"errors"`
+	Name          string            `yaml:"name"`
+	Method        string            `yaml:"method"`
+	Path          string            `yaml:"path"`
+	Headers       map[string]string `yaml:"headers"`
+	Body          string            `yaml:"body"`
+	Query         string            `yaml:"query"`
+	Errors        []string          `yaml:"errors"`
+	VariantTitles []string          `yaml:"variantTitles"`
+	SchemaPath    string            `yaml:"schemaPath"`
 }
 
 func makeOutputPath(protofile, format string) string {

--- a/internal/converter/googleapi/paths.go
+++ b/internal/converter/googleapi/paths.go
@@ -269,18 +269,7 @@ func httpRuleToPathMap(opts options.Options, md protoreflect.MethodDescriptor, r
 				_, s := schema.MessageToSchema(opts, md.Input())
 				if s != nil {
 					// Remove path parameters from properties.
-					// When the message has oneOf fields, MessageToSchema wraps
-					// properties and oneOf under AllOf, setting s.Properties to nil.
-					// In that case, find the properties inside AllOf.
 					props := s.Properties
-					if props == nil && len(s.AllOf) > 0 {
-						for _, entry := range s.AllOf {
-							if es := entry.Schema(); es != nil && es.Properties != nil && es.Properties.Len() > 0 {
-								props = es.Properties
-								break
-							}
-						}
-					}
 					if props != nil {
 						for name := range fieldNamesInPath {
 							props.Delete(name)
@@ -294,7 +283,10 @@ func httpRuleToPathMap(opts options.Options, md protoreflect.MethodDescriptor, r
 							}
 						}
 					}
-					hasContent := (props != nil && props.Len() > 0) || len(s.AllOf) > 0 || len(s.OneOf) > 0
+					hasContent := (props != nil && props.Len() > 0) ||
+						len(s.AllOf) > 0 ||
+						len(s.OneOf) > 0 ||
+						len(s.AnyOf) > 0
 					if hasContent {
 						op.RequestBody = util.MethodToRequestBody(opts, md, base.CreateSchemaProxy(s), false)
 					}

--- a/internal/converter/schema/schema.go
+++ b/internal/converter/schema/schema.go
@@ -84,21 +84,12 @@ func MessageToSchema(opts options.Options, tt protoreflect.MessageDescriptor) (s
 			allOfs = append(allOfs, makeOneOfGroup(opts, items))
 		}
 		if len(allOfs) == 1 {
-			s.OneOf = allOfs[0].Schema().OneOf
+			group := allOfs[0].Schema()
+			s.AnyOf = group.AnyOf
+			s.Not = group.Not
 		} else {
 			s.AllOf = append(s.AllOf, allOfs...)
 		}
-	}
-
-	// if there are oneOfs and properties, we should merge them under a allOf.
-	// having properties and oneOfs at the same level creates conflicts.
-	if len(s.OneOf) > 0 && s.Properties.Len() > 0 {
-		s.AllOf = append(s.AllOf,
-			base.CreateSchemaProxy(&base.Schema{Properties: s.Properties}),
-			base.CreateSchemaProxy(&base.Schema{OneOf: s.OneOf}),
-		)
-		s.Properties = nil
-		s.OneOf = nil
 	}
 
 	// Apply Updates from Options
@@ -247,8 +238,8 @@ func ReferenceFieldToSchema(opts options.Options, parent *base.SchemaProxy, tt p
 }
 
 func makeOneOfGroup(opts options.Options, fields []protoreflect.FieldDescriptor) *base.SchemaProxy {
-	rootSchemas := make([]*base.SchemaProxy, 0, len(fields)+1)
-	presence := make([]*base.SchemaProxy, 0, len(fields))
+	rootSchemas := make([]*base.SchemaProxy, 0, len(fields))
+	fieldNames := make([]string, 0, len(fields))
 	for _, field := range fields {
 		schema := &base.Schema{
 			/*
@@ -264,21 +255,43 @@ func makeOneOfGroup(opts options.Options, fields []protoreflect.FieldDescriptor)
 		fieldName := util.MakeFieldName(opts, field)
 		propSchema := FieldToSchema(opts, base.CreateSchemaProxy(schema), field)
 		schema.Properties.Set(fieldName, propSchema)
-		schema.Required = []string{fieldName}
 
 		rootSchemas = append(rootSchemas, base.CreateSchemaProxy(schema))
-		presence = append(presence, base.CreateSchemaProxy(&base.Schema{Required: []string{fieldName}}))
+		fieldNames = append(fieldNames, fieldName)
 	}
+	group := &base.Schema{AnyOf: rootSchemas}
 
-	// A protobuf oneof is at most one, not exactly one: a message with no member
-	// set serializes with all of them absent, so without a branch admitting that
-	// state every such message fails validation. (buf.validate.oneof).required
-	// tightens it back to exactly one and is applied by the protovalidate feature.
-	rootSchemas = append(rootSchemas, base.CreateSchemaProxy(&base.Schema{
-		Not: base.CreateSchemaProxy(&base.Schema{AnyOf: presence}),
-	}))
+	// Keep the rendered variants limited to real fields. The variants are
+	// optional because a plain protobuf oneof permits no member to be set, so
+	// at-most-one is carried by a sibling constraint instead. Enumerating the
+	// forbidden pairs would grow with the square of the member count; forbid
+	// "some member set, but not exactly one" instead, which says the same thing
+	// with two presence lists. It sits under not, which no documentation
+	// renderer reads as a list of variants. (buf.validate.oneof).required
+	// layers exactly-one on top in the protovalidate feature.
+	if len(fieldNames) > 1 {
+		group.Not = base.CreateSchemaProxy(&base.Schema{
+			AllOf: []*base.SchemaProxy{
+				base.CreateSchemaProxy(&base.Schema{AnyOf: presenceOf(fieldNames)}),
+				base.CreateSchemaProxy(&base.Schema{
+					Not: base.CreateSchemaProxy(&base.Schema{OneOf: presenceOf(fieldNames)}),
+				}),
+			},
+		})
+	}
+	return base.CreateSchemaProxy(group)
+}
 
-	return base.CreateSchemaProxy(&base.Schema{OneOf: rootSchemas})
+// presenceOf builds one "this field is set" branch per name. oneOf over them
+// matches when exactly one is set, anyOf when at least one is.
+func presenceOf(fieldNames []string) []*base.SchemaProxy {
+	branches := make([]*base.SchemaProxy, 0, len(fieldNames))
+	for _, fieldName := range fieldNames {
+		branches = append(branches, base.CreateSchemaProxy(&base.Schema{
+			Required: []string{fieldName},
+		}))
+	}
+	return branches
 }
 
 func appendType(s *base.Schema, newType string) {

--- a/internal/converter/testdata/jsonschema/output/jsonschema.jsonschema.json
+++ b/internal/converter/testdata/jsonschema/output/jsonschema.jsonschema.json
@@ -109,148 +109,154 @@
     },
     "jsonschema.User": {
       "type": "object",
-      "allOf": [
+      "anyOf": [
         {
+          "type": "object",
           "properties": {
-            "id": {
+            "email": {
               "type": "string",
-              "title": "id",
-              "description": "id is the unique identifier of the user."
-            },
-            "name": {
-              "type": [
-                "string",
-                "null"
-              ],
-              "title": "name",
-              "description": "name is the display name of the user."
-            },
-            "role": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/jsonschema.Role"
-                }
-              ],
-              "title": "role",
-              "description": "role determines what the user can do."
-            },
-            "createdAt": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/google.protobuf.Timestamp"
-                }
-              ],
-              "title": "created_at",
-              "description": "created_at is when the user signed up."
-            },
-            "sessionTtl": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/google.protobuf.Duration"
-                }
-              ],
-              "title": "session_ttl",
-              "description": "session_ttl is how long the user's sessions last."
-            },
-            "metadata": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/google.protobuf.Struct"
-                }
-              ],
-              "title": "metadata",
-              "description": "metadata is a set of arbitrary details about the user."
-            },
-            "labels": {
-              "type": "object",
-              "title": "labels",
-              "additionalProperties": {
-                "type": "string",
-                "title": "value"
-              },
-              "description": "labels are free-form key/value annotations."
-            },
-            "aliases": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "title": "aliases",
-              "description": "aliases are alternative names for the user."
-            },
-            "loginCount": {
-              "type": "string",
-              "title": "login_count",
-              "format": "int64",
-              "description": "login_count is the number of times the user logged in."
-            },
-            "avatar": {
-              "type": "string",
-              "title": "avatar",
-              "format": "byte",
-              "description": "avatar is the user's profile image."
-            },
-            "address": {
-              "allOf": [
-                {
-                  "$ref": "#/$defs/jsonschema.User.Address"
-                }
-              ],
-              "title": "address",
-              "description": "address is where the user lives."
+              "title": "email",
+              "description": "email is an email address."
             }
-          }
+          },
+          "title": "email"
         },
         {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "type": "string",
-                  "title": "email",
-                  "description": "email is an email address."
-                }
-              },
-              "title": "email",
-              "required": [
-                "email"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "phone": {
-                  "type": "string",
-                  "title": "phone",
-                  "description": "phone is a phone number."
-                }
-              },
+          "type": "object",
+          "properties": {
+            "phone": {
+              "type": "string",
               "title": "phone",
-              "required": [
-                "phone"
-              ]
-            },
-            {
-              "not": {
-                "anyOf": [
-                  {
-                    "required": [
-                      "email"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "phone"
-                    ]
-                  }
-                ]
-              }
+              "description": "phone is a phone number."
             }
-          ]
+          },
+          "title": "phone"
         }
       ],
       "unevaluatedProperties": false,
+      "not": {
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "email"
+                ]
+              },
+              {
+                "required": [
+                  "phone"
+                ]
+              }
+            ]
+          },
+          {
+            "not": {
+              "oneOf": [
+                {
+                  "required": [
+                    "email"
+                  ]
+                },
+                {
+                  "required": [
+                    "phone"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "id",
+          "description": "id is the unique identifier of the user."
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "title": "name",
+          "description": "name is the display name of the user."
+        },
+        "role": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/jsonschema.Role"
+            }
+          ],
+          "title": "role",
+          "description": "role determines what the user can do."
+        },
+        "createdAt": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/google.protobuf.Timestamp"
+            }
+          ],
+          "title": "created_at",
+          "description": "created_at is when the user signed up."
+        },
+        "sessionTtl": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/google.protobuf.Duration"
+            }
+          ],
+          "title": "session_ttl",
+          "description": "session_ttl is how long the user's sessions last."
+        },
+        "metadata": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/google.protobuf.Struct"
+            }
+          ],
+          "title": "metadata",
+          "description": "metadata is a set of arbitrary details about the user."
+        },
+        "labels": {
+          "type": "object",
+          "title": "labels",
+          "additionalProperties": {
+            "type": "string",
+            "title": "value"
+          },
+          "description": "labels are free-form key/value annotations."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "aliases",
+          "description": "aliases are alternative names for the user."
+        },
+        "loginCount": {
+          "type": "string",
+          "title": "login_count",
+          "format": "int64",
+          "description": "login_count is the number of times the user logged in."
+        },
+        "avatar": {
+          "type": "string",
+          "title": "avatar",
+          "format": "byte",
+          "description": "avatar is the user's profile image."
+        },
+        "address": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/jsonschema.User.Address"
+            }
+          ],
+          "title": "address",
+          "description": "address is where the user lives."
+        }
+      },
       "title": "User",
       "description": "User is a person with an account."
     },

--- a/internal/converter/testdata/jsonschema/output/notification.jsonschema.json
+++ b/internal/converter/testdata/jsonschema/output/notification.jsonschema.json
@@ -3,7 +3,7 @@
   "$defs": {
     "jsonschema.Notification": {
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "type": "object",
           "properties": {
@@ -17,10 +17,7 @@
               "description": "push is a mobile push delivery target."
             }
           },
-          "title": "push",
-          "required": [
-            "push"
-          ]
+          "title": "push"
         },
         {
           "type": "object",
@@ -31,13 +28,13 @@
               "description": "webhook_url is an HTTP endpoint to call."
             }
           },
-          "title": "webhook_url",
-          "required": [
-            "webhookUrl"
-          ]
-        },
-        {
-          "not": {
+          "title": "webhook_url"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "not": {
+        "allOf": [
+          {
             "anyOf": [
               {
                 "required": [
@@ -50,10 +47,25 @@
                 ]
               }
             ]
+          },
+          {
+            "not": {
+              "oneOf": [
+                {
+                  "required": [
+                    "push"
+                  ]
+                },
+                {
+                  "required": [
+                    "webhookUrl"
+                  ]
+                }
+              ]
+            }
           }
-        }
-      ],
-      "unevaluatedProperties": false,
+        ]
+      },
       "title": "Notification",
       "description": "Notification is a message delivered to a user. Its oneof mixes a scalar\n member with a message-type member."
     },

--- a/internal/converter/testdata/oneof_rendering/oneof_rendering.cases.yaml
+++ b/internal/converter/testdata/oneof_rendering/oneof_rendering.cases.yaml
@@ -1,0 +1,60 @@
+cases:
+  - name: "plain-oneof-no-member"
+    path: "/compliance"
+    body: '{"reference": "case-1"}'
+    variantTitles: ["kyb", "kyc"]
+    headers:
+      Content-Type: application/json
+
+  - name: "plain-oneof-one-member"
+    path: "/compliance"
+    body: '{"reference": "case-1", "kyc": "person"}'
+    headers:
+      Content-Type: application/json
+
+  - name: "plain-oneof-two-members"
+    path: "/compliance"
+    body: '{"kyc": "person", "kyb": "business"}'
+    headers:
+      Content-Type: application/json
+    errors:
+      - ".*"
+
+  - name: "plain-oneof-additional-property"
+    path: "/compliance"
+    body: '{"kyc": "person", "undeclared": true}'
+    headers:
+      Content-Type: application/json
+    errors:
+      - ".*"
+
+  - name: "required-oneof-no-member"
+    path: "/required-compliance"
+    body: '{"reference": "case-2"}'
+    variantTitles: ["kyb", "kyc"]
+    headers:
+      Content-Type: application/json
+    errors:
+      - ".*"
+
+  - name: "required-oneof-one-member"
+    path: "/required-compliance"
+    body: '{"reference": "case-2", "kyb": "business"}'
+    headers:
+      Content-Type: application/json
+
+  - name: "required-oneof-two-members"
+    path: "/required-compliance"
+    body: '{"kyc": "person", "kyb": "business"}'
+    headers:
+      Content-Type: application/json
+    errors:
+      - ".*"
+
+  - name: "required-oneof-additional-property"
+    path: "/required-compliance"
+    body: '{"kyb": "business", "undeclared": true}'
+    headers:
+      Content-Type: application/json
+    errors:
+      - ".*"

--- a/internal/converter/testdata/oneof_rendering/oneof_rendering.proto
+++ b/internal/converter/testdata/oneof_rendering/oneof_rendering.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package oneof_rendering;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/empty.proto";
+
+service ComplianceService {
+  rpc CreateCompliance(ComplianceRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/compliance"
+      body: "*"
+    };
+  }
+
+  rpc CreateRequiredCompliance(RequiredComplianceRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/required-compliance"
+      body: "*"
+    };
+  }
+}
+
+message ComplianceRequest {
+  string reference = 1;
+  oneof subject {
+    string kyc = 2;
+    string kyb = 3;
+  }
+}
+
+message RequiredComplianceRequest {
+  string reference = 1;
+  oneof subject {
+    option (buf.validate.oneof).required = true;
+    string kyc = 2;
+    string kyb = 3;
+  }
+}

--- a/internal/converter/testdata/oneof_rendering/output/oneof_rendering.openapi.json
+++ b/internal/converter/testdata/oneof_rendering/output/oneof_rendering.openapi.json
@@ -1,0 +1,236 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "oneof_rendering",
+    "description": "API documentation for oneof_rendering",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/compliance": {
+      "post": {
+        "tags": [
+          "oneof_rendering.ComplianceService"
+        ],
+        "summary": "CreateCompliance",
+        "operationId": "oneof_rendering.ComplianceService.CreateCompliance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/oneof_rendering.ComplianceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/google.protobuf.Empty"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/required-compliance": {
+      "post": {
+        "tags": [
+          "oneof_rendering.ComplianceService"
+        ],
+        "summary": "CreateRequiredCompliance",
+        "operationId": "oneof_rendering.ComplianceService.CreateRequiredCompliance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/oneof_rendering.RequiredComplianceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/google.protobuf.Empty"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "google.protobuf.Empty": {
+        "type": "object",
+        "description": "An empty JSON object."
+      },
+      "oneof_rendering.ComplianceRequest": {
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kyb": {
+                "type": "string",
+                "title": "kyb"
+              }
+            },
+            "title": "kyb"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kyc": {
+                "type": "string",
+                "title": "kyc"
+              }
+            },
+            "title": "kyc"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "kyb"
+                  ]
+                },
+                {
+                  "required": [
+                    "kyc"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "kyb"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "kyc"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "reference": {
+            "type": "string",
+            "title": "reference"
+          }
+        },
+        "title": "ComplianceRequest"
+      },
+      "oneof_rendering.RequiredComplianceRequest": {
+        "type": "object",
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "kyc"
+                ]
+              },
+              {
+                "required": [
+                  "kyb"
+                ]
+              }
+            ]
+          }
+        ],
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kyb": {
+                "type": "string",
+                "title": "kyb"
+              }
+            },
+            "title": "kyb"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kyc": {
+                "type": "string",
+                "title": "kyc"
+              }
+            },
+            "title": "kyc"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "kyb"
+                  ]
+                },
+                {
+                  "required": [
+                    "kyc"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "kyb"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "kyc"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "reference": {
+            "type": "string",
+            "title": "reference"
+          }
+        },
+        "title": "RequiredComplianceRequest"
+      }
+    }
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "oneof_rendering.ComplianceService"
+    }
+  ]
+}

--- a/internal/converter/testdata/oneof_rendering/output/oneof_rendering.openapi.yaml
+++ b/internal/converter/testdata/oneof_rendering/output/oneof_rendering.openapi.yaml
@@ -1,0 +1,126 @@
+openapi: 3.1.0
+info:
+  title: oneof_rendering
+  description: API documentation for oneof_rendering
+  version: 1.0.0
+paths:
+  /compliance:
+    post:
+      tags:
+        - oneof_rendering.ComplianceService
+      summary: CreateCompliance
+      operationId: oneof_rendering.ComplianceService.CreateCompliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/oneof_rendering.ComplianceRequest'
+        required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/google.protobuf.Empty'
+  /required-compliance:
+    post:
+      tags:
+        - oneof_rendering.ComplianceService
+      summary: CreateRequiredCompliance
+      operationId: oneof_rendering.ComplianceService.CreateRequiredCompliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/oneof_rendering.RequiredComplianceRequest'
+        required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/google.protobuf.Empty'
+components:
+  schemas:
+    google.protobuf.Empty:
+      type: object
+      description: An empty JSON object.
+    oneof_rendering.ComplianceRequest:
+      type: object
+      anyOf:
+        - type: object
+          properties:
+            kyb:
+              type: string
+              title: kyb
+          title: kyb
+        - type: object
+          properties:
+            kyc:
+              type: string
+              title: kyc
+          title: kyc
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - kyb
+              - required:
+                  - kyc
+          - not:
+              oneOf:
+                - required:
+                    - kyb
+                - required:
+                    - kyc
+      properties:
+        reference:
+          type: string
+          title: reference
+      title: ComplianceRequest
+    oneof_rendering.RequiredComplianceRequest:
+      type: object
+      allOf:
+        - oneOf:
+            - required:
+                - kyc
+            - required:
+                - kyb
+      anyOf:
+        - type: object
+          properties:
+            kyb:
+              type: string
+              title: kyb
+          title: kyb
+        - type: object
+          properties:
+            kyc:
+              type: string
+              title: kyc
+          title: kyc
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - kyb
+              - required:
+                  - kyc
+          - not:
+              oneOf:
+                - required:
+                    - kyb
+                - required:
+                    - kyc
+      properties:
+        reference:
+          type: string
+          title: reference
+      title: RequiredComplianceRequest
+security: []
+tags:
+  - name: oneof_rendering.ComplianceService

--- a/internal/converter/testdata/path_params/output/path_params.openapi.json
+++ b/internal/converter/testdata/path_params/output/path_params.openapi.json
@@ -31,64 +31,71 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "allOf": [
-                  {},
+                "anyOf": [
                   {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "profile": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/path_params.Profile"
-                              }
-                            ],
-                            "title": "profile"
+                    "type": "object",
+                    "properties": {
+                      "profile": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/path_params.Profile"
                           }
-                        },
-                        "title": "profile",
-                        "required": [
-                          "profile"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "settings": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/path_params.Settings"
-                              }
-                            ],
-                            "title": "settings"
-                          }
-                        },
-                        "title": "settings",
-                        "required": [
-                          "settings"
-                        ]
-                      },
-                      {
-                        "not": {
-                          "anyOf": [
-                            {
-                              "required": [
-                                "profile"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "settings"
-                              ]
-                            }
-                          ]
-                        }
+                        ],
+                        "title": "profile"
                       }
-                    ]
+                    },
+                    "title": "profile"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "settings": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/path_params.Settings"
+                          }
+                        ],
+                        "title": "settings"
+                      }
+                    },
+                    "title": "settings"
                   }
                 ],
                 "unevaluatedProperties": false,
+                "not": {
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "profile"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "settings"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "not": {
+                        "oneOf": [
+                          {
+                            "required": [
+                              "profile"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "settings"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
                 "title": "UpdateWithOneofRequest"
               }
             }
@@ -226,71 +233,77 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "allOf": [
+                "anyOf": [
                   {
+                    "type": "object",
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "title": "name"
+                      "profile": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/path_params.Profile"
+                          }
+                        ],
+                        "title": "profile"
                       }
-                    }
+                    },
+                    "title": "profile"
                   },
                   {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "profile": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/path_params.Profile"
-                              }
-                            ],
-                            "title": "profile"
+                    "type": "object",
+                    "properties": {
+                      "settings": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/path_params.Settings"
                           }
-                        },
-                        "title": "profile",
-                        "required": [
-                          "profile"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "settings": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/path_params.Settings"
-                              }
-                            ],
-                            "title": "settings"
-                          }
-                        },
-                        "title": "settings",
-                        "required": [
-                          "settings"
-                        ]
-                      },
-                      {
-                        "not": {
-                          "anyOf": [
-                            {
-                              "required": [
-                                "profile"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "settings"
-                              ]
-                            }
-                          ]
-                        }
+                        ],
+                        "title": "settings"
                       }
-                    ]
+                    },
+                    "title": "settings"
                   }
                 ],
                 "unevaluatedProperties": false,
+                "not": {
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "profile"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "settings"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "not": {
+                        "oneOf": [
+                          {
+                            "required": [
+                              "profile"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "settings"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "name"
+                  }
+                },
                 "title": "UpdateRequest",
                 "description": "UpdateRequest has a path param, regular fields, and a oneOf.\n This tests that the requestBody is generated correctly when\n MessageToSchema wraps properties+oneOf under AllOf."
               }
@@ -544,75 +557,81 @@
       },
       "path_params.UpdateRequest": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "id": {
-                "type": "string",
-                "title": "id"
-              },
-              "name": {
-                "type": "string",
-                "title": "name"
+              "profile": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/path_params.Profile"
+                  }
+                ],
+                "title": "profile"
               }
-            }
+            },
+            "title": "profile"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "profile": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/path_params.Profile"
-                      }
-                    ],
-                    "title": "profile"
+            "type": "object",
+            "properties": {
+              "settings": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/path_params.Settings"
                   }
-                },
-                "title": "profile",
-                "required": [
-                  "profile"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "settings": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/path_params.Settings"
-                      }
-                    ],
-                    "title": "settings"
-                  }
-                },
-                "title": "settings",
-                "required": [
-                  "settings"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "profile"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "settings"
-                      ]
-                    }
-                  ]
-                }
+                ],
+                "title": "settings"
               }
-            ]
+            },
+            "title": "settings"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "profile"
+                  ]
+                },
+                {
+                  "required": [
+                    "settings"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "profile"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "settings"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "id"
+          },
+          "name": {
+            "type": "string",
+            "title": "name"
+          }
+        },
         "title": "UpdateRequest",
         "required": [
           "id"
@@ -621,71 +640,77 @@
       },
       "path_params.UpdateWithOneofRequest": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "accountId": {
-                "type": "string",
-                "title": "account_id"
+              "profile": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/path_params.Profile"
+                  }
+                ],
+                "title": "profile"
               }
-            }
+            },
+            "title": "profile"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "profile": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/path_params.Profile"
-                      }
-                    ],
-                    "title": "profile"
+            "type": "object",
+            "properties": {
+              "settings": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/path_params.Settings"
                   }
-                },
-                "title": "profile",
-                "required": [
-                  "profile"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "settings": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/path_params.Settings"
-                      }
-                    ],
-                    "title": "settings"
-                  }
-                },
-                "title": "settings",
-                "required": [
-                  "settings"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "profile"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "settings"
-                      ]
-                    }
-                  ]
-                }
+                ],
+                "title": "settings"
               }
-            ]
+            },
+            "title": "settings"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "profile"
+                  ]
+                },
+                {
+                  "required": [
+                    "settings"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "profile"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "settings"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "accountId": {
+            "type": "string",
+            "title": "account_id"
+          }
+        },
         "title": "UpdateWithOneofRequest"
       }
     }

--- a/internal/converter/testdata/path_params/output/path_params.openapi.yaml
+++ b/internal/converter/testdata/path_params/output/path_params.openapi.yaml
@@ -26,34 +26,35 @@ paths:
           application/json:
             schema:
               type: object
-              allOf:
-                - {}
-                - oneOf:
-                    - type: object
-                      properties:
-                        profile:
-                          allOf:
-                            - $ref: '#/components/schemas/path_params.Profile'
-                          title: profile
+              anyOf:
+                - type: object
+                  properties:
+                    profile:
+                      allOf:
+                        - $ref: '#/components/schemas/path_params.Profile'
                       title: profile
-                      required:
-                        - profile
-                    - type: object
-                      properties:
-                        settings:
-                          allOf:
-                            - $ref: '#/components/schemas/path_params.Settings'
-                          title: settings
+                  title: profile
+                - type: object
+                  properties:
+                    settings:
+                      allOf:
+                        - $ref: '#/components/schemas/path_params.Settings'
                       title: settings
-                      required:
-                        - settings
-                    - not:
-                        anyOf:
-                          - required:
-                              - profile
-                          - required:
-                              - settings
+                  title: settings
               unevaluatedProperties: false
+              not:
+                allOf:
+                  - anyOf:
+                      - required:
+                          - profile
+                      - required:
+                          - settings
+                  - not:
+                      oneOf:
+                        - required:
+                            - profile
+                        - required:
+                            - settings
               title: UpdateWithOneofRequest
         required: true
       responses:
@@ -142,37 +143,39 @@ paths:
           application/json:
             schema:
               type: object
-              allOf:
-                - properties:
-                    name:
-                      type: string
-                      title: name
-                - oneOf:
-                    - type: object
-                      properties:
-                        profile:
-                          allOf:
-                            - $ref: '#/components/schemas/path_params.Profile'
-                          title: profile
+              anyOf:
+                - type: object
+                  properties:
+                    profile:
+                      allOf:
+                        - $ref: '#/components/schemas/path_params.Profile'
                       title: profile
-                      required:
-                        - profile
-                    - type: object
-                      properties:
-                        settings:
-                          allOf:
-                            - $ref: '#/components/schemas/path_params.Settings'
-                          title: settings
+                  title: profile
+                - type: object
+                  properties:
+                    settings:
+                      allOf:
+                        - $ref: '#/components/schemas/path_params.Settings'
                       title: settings
-                      required:
-                        - settings
-                    - not:
-                        anyOf:
-                          - required:
-                              - profile
-                          - required:
-                              - settings
+                  title: settings
               unevaluatedProperties: false
+              not:
+                allOf:
+                  - anyOf:
+                      - required:
+                          - profile
+                      - required:
+                          - settings
+                  - not:
+                      oneOf:
+                        - required:
+                            - profile
+                        - required:
+                            - settings
+              properties:
+                name:
+                  type: string
+                  title: name
               title: UpdateRequest
               description: |-
                 UpdateRequest has a path param, regular fields, and a oneOf.
@@ -344,40 +347,42 @@ components:
       additionalProperties: false
     path_params.UpdateRequest:
       type: object
-      allOf:
-        - properties:
-            id:
-              type: string
-              title: id
-            name:
-              type: string
-              title: name
-        - oneOf:
-            - type: object
-              properties:
-                profile:
-                  allOf:
-                    - $ref: '#/components/schemas/path_params.Profile'
-                  title: profile
+      anyOf:
+        - type: object
+          properties:
+            profile:
+              allOf:
+                - $ref: '#/components/schemas/path_params.Profile'
               title: profile
-              required:
-                - profile
-            - type: object
-              properties:
-                settings:
-                  allOf:
-                    - $ref: '#/components/schemas/path_params.Settings'
-                  title: settings
+          title: profile
+        - type: object
+          properties:
+            settings:
+              allOf:
+                - $ref: '#/components/schemas/path_params.Settings'
               title: settings
-              required:
-                - settings
-            - not:
-                anyOf:
-                  - required:
-                      - profile
-                  - required:
-                      - settings
+          title: settings
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - profile
+              - required:
+                  - settings
+          - not:
+              oneOf:
+                - required:
+                    - profile
+                - required:
+                    - settings
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
       title: UpdateRequest
       required:
         - id
@@ -387,37 +392,39 @@ components:
          MessageToSchema wraps properties+oneOf under AllOf.
     path_params.UpdateWithOneofRequest:
       type: object
-      allOf:
-        - properties:
-            accountId:
-              type: string
-              title: account_id
-        - oneOf:
-            - type: object
-              properties:
-                profile:
-                  allOf:
-                    - $ref: '#/components/schemas/path_params.Profile'
-                  title: profile
+      anyOf:
+        - type: object
+          properties:
+            profile:
+              allOf:
+                - $ref: '#/components/schemas/path_params.Profile'
               title: profile
-              required:
-                - profile
-            - type: object
-              properties:
-                settings:
-                  allOf:
-                    - $ref: '#/components/schemas/path_params.Settings'
-                  title: settings
+          title: profile
+        - type: object
+          properties:
+            settings:
+              allOf:
+                - $ref: '#/components/schemas/path_params.Settings'
               title: settings
-              required:
-                - settings
-            - not:
-                anyOf:
-                  - required:
-                      - profile
-                  - required:
-                      - settings
+          title: settings
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - profile
+              - required:
+                  - settings
+          - not:
+              oneOf:
+                - required:
+                    - profile
+                - required:
+                    - settings
+      properties:
+        accountId:
+          type: string
+          title: account_id
       title: UpdateWithOneofRequest
 security: []
 tags:

--- a/internal/converter/testdata/path_params/path_params.cases.yaml
+++ b/internal/converter/testdata/path_params/path_params.cases.yaml
@@ -22,3 +22,12 @@ cases:
       Content-Type: application/json
     errors:
       - ".*"
+
+  - name: "oneof-only-body-after-path-param-removal"
+    method: PATCH
+    path: "/accounts/abc"
+    schemaPath: "/accounts/{accountId}"
+    body: '{"profile": {"displayName": "test"}}'
+    variantTitles: ["profile", "settings"]
+    headers:
+      Content-Type: application/json

--- a/internal/converter/testdata/proto_names/output/googleapi.openapi.json
+++ b/internal/converter/testdata/proto_names/output/googleapi.openapi.json
@@ -114,64 +114,71 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "allOf": [
-                  {},
+                "anyOf": [
                   {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "profile": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Profile"
-                              }
-                            ],
-                            "title": "profile"
+                    "type": "object",
+                    "properties": {
+                      "profile": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Profile"
                           }
-                        },
-                        "title": "profile",
-                        "required": [
-                          "profile"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "settings": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Settings"
-                              }
-                            ],
-                            "title": "settings"
-                          }
-                        },
-                        "title": "settings",
-                        "required": [
-                          "settings"
-                        ]
-                      },
-                      {
-                        "not": {
-                          "anyOf": [
-                            {
-                              "required": [
-                                "profile"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "settings"
-                              ]
-                            }
-                          ]
-                        }
+                        ],
+                        "title": "profile"
                       }
-                    ]
+                    },
+                    "title": "profile"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "settings": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Settings"
+                          }
+                        ],
+                        "title": "settings"
+                      }
+                    },
+                    "title": "settings"
                   }
                 ],
                 "unevaluatedProperties": false,
+                "not": {
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "profile"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "settings"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "not": {
+                        "oneOf": [
+                          {
+                            "required": [
+                              "profile"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "settings"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
                 "title": "UpdateWithOneofRequest"
               }
             }
@@ -461,71 +468,77 @@
       },
       "proto_names.io.swagger.petstore.v2.UpdateWithOneofRequest": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "account_id": {
-                "type": "string",
-                "title": "account_id"
+              "profile": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Profile"
+                  }
+                ],
+                "title": "profile"
               }
-            }
+            },
+            "title": "profile"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "profile": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Profile"
-                      }
-                    ],
-                    "title": "profile"
+            "type": "object",
+            "properties": {
+              "settings": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Settings"
                   }
-                },
-                "title": "profile",
-                "required": [
-                  "profile"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "settings": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/proto_names.io.swagger.petstore.v2.Settings"
-                      }
-                    ],
-                    "title": "settings"
-                  }
-                },
-                "title": "settings",
-                "required": [
-                  "settings"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "profile"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "settings"
-                      ]
-                    }
-                  ]
-                }
+                ],
+                "title": "settings"
               }
-            ]
+            },
+            "title": "settings"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "profile"
+                  ]
+                },
+                {
+                  "required": [
+                    "settings"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "profile"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "settings"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "title": "account_id"
+          }
+        },
         "title": "UpdateWithOneofRequest"
       }
     }

--- a/internal/converter/testdata/proto_names/output/googleapi.openapi.yaml
+++ b/internal/converter/testdata/proto_names/output/googleapi.openapi.yaml
@@ -78,34 +78,35 @@ paths:
           application/json:
             schema:
               type: object
-              allOf:
-                - {}
-                - oneOf:
-                    - type: object
-                      properties:
-                        profile:
-                          allOf:
-                            - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Profile'
-                          title: profile
+              anyOf:
+                - type: object
+                  properties:
+                    profile:
+                      allOf:
+                        - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Profile'
                       title: profile
-                      required:
-                        - profile
-                    - type: object
-                      properties:
-                        settings:
-                          allOf:
-                            - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Settings'
-                          title: settings
+                  title: profile
+                - type: object
+                  properties:
+                    settings:
+                      allOf:
+                        - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Settings'
                       title: settings
-                      required:
-                        - settings
-                    - not:
-                        anyOf:
-                          - required:
-                              - profile
-                          - required:
-                              - settings
+                  title: settings
               unevaluatedProperties: false
+              not:
+                allOf:
+                  - anyOf:
+                      - required:
+                          - profile
+                      - required:
+                          - settings
+                  - not:
+                      oneOf:
+                        - required:
+                            - profile
+                        - required:
+                            - settings
               title: UpdateWithOneofRequest
         required: true
       responses:
@@ -306,37 +307,39 @@ components:
       additionalProperties: false
     proto_names.io.swagger.petstore.v2.UpdateWithOneofRequest:
       type: object
-      allOf:
-        - properties:
-            account_id:
-              type: string
-              title: account_id
-        - oneOf:
-            - type: object
-              properties:
-                profile:
-                  allOf:
-                    - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Profile'
-                  title: profile
+      anyOf:
+        - type: object
+          properties:
+            profile:
+              allOf:
+                - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Profile'
               title: profile
-              required:
-                - profile
-            - type: object
-              properties:
-                settings:
-                  allOf:
-                    - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Settings'
-                  title: settings
+          title: profile
+        - type: object
+          properties:
+            settings:
+              allOf:
+                - $ref: '#/components/schemas/proto_names.io.swagger.petstore.v2.Settings'
               title: settings
-              required:
-                - settings
-            - not:
-                anyOf:
-                  - required:
-                      - profile
-                  - required:
-                      - settings
+          title: settings
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - profile
+              - required:
+                  - settings
+          - not:
+              oneOf:
+                - required:
+                    - profile
+                - required:
+                    - settings
+      properties:
+        account_id:
+          type: string
+          title: account_id
       title: UpdateWithOneofRequest
 security: []
 tags:

--- a/internal/converter/testdata/standard/output/envoy.asyncapi.json
+++ b/internal/converter/testdata/standard/output/envoy.asyncapi.json
@@ -97,8 +97,7 @@
   "components": {
     "schemas": {
       "envoy.config.core.v3.Address": {
-        "description": "Addresses specify either a logical or physical address and port, which are\n used to tell Envoy where to bind/listen, connect to upstream and find\n management servers.",
-        "oneOf": [
+        "anyOf": [
           {
             "properties": {
               "envoyInternalAddress": {
@@ -111,9 +110,6 @@
                 "title": "envoy_internal_address"
               }
             },
-            "required": [
-              "envoyInternalAddress"
-            ],
             "title": "envoy_internal_address",
             "type": "object"
           },
@@ -128,9 +124,6 @@
                 "title": "pipe"
               }
             },
-            "required": [
-              "pipe"
-            ],
             "title": "pipe",
             "type": "object"
           },
@@ -145,14 +138,14 @@
                 "title": "socket_address"
               }
             },
-            "required": [
-              "socketAddress"
-            ],
             "title": "socket_address",
             "type": "object"
-          },
-          {
-            "not": {
+          }
+        ],
+        "description": "Addresses specify either a logical or physical address and port, which are\n used to tell Envoy where to bind/listen, connect to upstream and find\n management servers.",
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -170,9 +163,30 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "envoyInternalAddress"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "pipe"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "socketAddress"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
+          ]
+        },
         "title": "Address",
         "type": "object",
         "unevaluatedProperties": false
@@ -217,47 +231,27 @@
         "type": "object"
       },
       "envoy.config.core.v3.EnvoyInternalAddress": {
-        "allOf": [
+        "anyOf": [
           {
             "properties": {
-              "endpointId": {
-                "description": "Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a\n single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for\n example, may be set to the final destination IP for the target internal listener.",
-                "title": "endpoint_id",
+              "serverListenerName": {
+                "description": "Specifies the :ref:`name \u003cenvoy_v3_api_field_config.listener.v3.Listener.name\u003e` of the\n internal listener.",
+                "title": "server_listener_name",
                 "type": "string"
               }
-            }
-          },
-          {
-            "oneOf": [
-              {
-                "properties": {
-                  "serverListenerName": {
-                    "description": "Specifies the :ref:`name \u003cenvoy_v3_api_field_config.listener.v3.Listener.name\u003e` of the\n internal listener.",
-                    "title": "server_listener_name",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "serverListenerName"
-                ],
-                "title": "server_listener_name",
-                "type": "object"
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "serverListenerName"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
+            },
+            "title": "server_listener_name",
+            "type": "object"
           }
         ],
         "description": "The address represents an envoy internal listener.\n [#comment: TODO(asraa): When address available, remove workaround from test/server/server_fuzz_test.cc:30.]",
+        "properties": {
+          "endpointId": {
+            "description": "Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a\n single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for\n example, may be set to the final destination IP for the target internal listener.",
+            "title": "endpoint_id",
+            "type": "string"
+          }
+        },
         "title": "EnvoyInternalAddress",
         "type": "object",
         "unevaluatedProperties": false
@@ -366,136 +360,142 @@
         "type": "object"
       },
       "envoy.config.core.v3.Node": {
-        "allOf": [
+        "anyOf": [
           {
             "properties": {
-              "clientFeatures": {
-                "description": "Client feature support list. These are well known features described\n in the Envoy API repository for a given major version of an API. Client features\n use reverse DNS naming scheme, for example ``com.acme.feature``.\n See :ref:`the list of features \u003cclient_features\u003e` that xDS client may\n support.",
-                "items": {
-                  "type": "string"
-                },
-                "title": "client_features",
-                "type": "array"
-              },
-              "cluster": {
-                "description": "Defines the local service cluster name where Envoy is running. Though\n optional, it should be set if any of the following features are used:\n :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`health check cluster\n verification\n \u003cenvoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher\u003e`,\n :ref:`runtime override directory \u003cenvoy_v3_api_msg_config.bootstrap.v3.Runtime\u003e`,\n :ref:`user agent addition\n \u003cenvoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent\u003e`,\n :ref:`HTTP global rate limiting \u003cconfig_http_filters_rate_limit\u003e`,\n :ref:`CDS \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-cluster`.",
-                "title": "cluster",
-                "type": "string"
-              },
-              "dynamicParameters": {
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/xds.core.v3.ContextParams"
-                    }
-                  ],
-                  "title": "value"
-                },
-                "description": "Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike\n other fields in this message). For example, the xDS client may have a shard identifier that\n changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the\n dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic\n parameter then appears in this field during future discovery requests.",
-                "title": "dynamic_parameters",
-                "type": "object"
-              },
-              "extensions": {
-                "description": "List of extensions and their versions supported by the node.",
-                "items": {
-                  "$ref": "#/components/schemas/envoy.config.core.v3.Extension"
-                },
-                "title": "extensions",
-                "type": "array"
-              },
-              "id": {
-                "description": "An opaque node identifier for the Envoy node. This also provides the local\n service node name. It should be set if any of the following features are\n used: :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`CDS\n \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-node`.",
-                "title": "id",
-                "type": "string"
-              },
-              "listeningAddresses": {
-                "deprecated": true,
-                "description": "Known listening ports on the node as a generic hint to the management server\n for filtering :ref:`listeners \u003cconfig_listeners\u003e` to be returned. For example,\n if there is a listener bound to port 80, the list can optionally contain the\n SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.",
-                "items": {
-                  "$ref": "#/components/schemas/envoy.config.core.v3.Address"
-                },
-                "title": "listening_addresses",
-                "type": "array"
-              },
-              "locality": {
+              "userAgentBuildVersion": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/envoy.config.core.v3.Locality"
+                    "$ref": "#/components/schemas/envoy.config.core.v3.BuildVersion"
                   }
                 ],
-                "description": "Locality specifying where the Envoy instance is running.",
-                "title": "locality"
-              },
-              "metadata": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Struct"
-                  }
-                ],
-                "description": "Opaque metadata extending the node identifier. Envoy will pass this\n directly to the management server.",
-                "title": "metadata"
-              },
-              "userAgentName": {
-                "description": "Free-form string that identifies the entity requesting config.\n E.g. \"envoy\" or \"grpc\"",
-                "title": "user_agent_name",
-                "type": "string"
+                "description": "Structured version of the entity requesting config.",
+                "title": "user_agent_build_version"
               }
-            }
+            },
+            "title": "user_agent_build_version",
+            "type": "object"
           },
           {
-            "oneOf": [
-              {
-                "properties": {
-                  "userAgentBuildVersion": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/envoy.config.core.v3.BuildVersion"
-                      }
-                    ],
-                    "description": "Structured version of the entity requesting config.",
-                    "title": "user_agent_build_version"
-                  }
-                },
-                "required": [
-                  "userAgentBuildVersion"
-                ],
-                "title": "user_agent_build_version",
-                "type": "object"
-              },
-              {
-                "properties": {
-                  "userAgentVersion": {
-                    "description": "Free-form string that identifies the version of the entity requesting config.\n E.g. \"1.12.2\" or \"abcd1234\", or \"SpecialEnvoyBuild\"",
-                    "title": "user_agent_version",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userAgentVersion"
-                ],
+            "properties": {
+              "userAgentVersion": {
+                "description": "Free-form string that identifies the version of the entity requesting config.\n E.g. \"1.12.2\" or \"abcd1234\", or \"SpecialEnvoyBuild\"",
                 "title": "user_agent_version",
-                "type": "object"
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "userAgentBuildVersion"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "userAgentVersion"
-                      ]
-                    }
-                  ]
-                }
+                "type": "string"
               }
-            ]
+            },
+            "title": "user_agent_version",
+            "type": "object"
           }
         ],
         "description": "Identifies a specific Envoy instance. The node identifier is presented to the\n management server, which may use this identifier to distinguish per Envoy\n configuration for serving.\n [#next-free-field: 13]",
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "userAgentBuildVersion"
+                  ]
+                },
+                {
+                  "required": [
+                    "userAgentVersion"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "userAgentBuildVersion"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "userAgentVersion"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "clientFeatures": {
+            "description": "Client feature support list. These are well known features described\n in the Envoy API repository for a given major version of an API. Client features\n use reverse DNS naming scheme, for example ``com.acme.feature``.\n See :ref:`the list of features \u003cclient_features\u003e` that xDS client may\n support.",
+            "items": {
+              "type": "string"
+            },
+            "title": "client_features",
+            "type": "array"
+          },
+          "cluster": {
+            "description": "Defines the local service cluster name where Envoy is running. Though\n optional, it should be set if any of the following features are used:\n :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`health check cluster\n verification\n \u003cenvoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher\u003e`,\n :ref:`runtime override directory \u003cenvoy_v3_api_msg_config.bootstrap.v3.Runtime\u003e`,\n :ref:`user agent addition\n \u003cenvoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent\u003e`,\n :ref:`HTTP global rate limiting \u003cconfig_http_filters_rate_limit\u003e`,\n :ref:`CDS \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-cluster`.",
+            "title": "cluster",
+            "type": "string"
+          },
+          "dynamicParameters": {
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/xds.core.v3.ContextParams"
+                }
+              ],
+              "title": "value"
+            },
+            "description": "Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike\n other fields in this message). For example, the xDS client may have a shard identifier that\n changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the\n dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic\n parameter then appears in this field during future discovery requests.",
+            "title": "dynamic_parameters",
+            "type": "object"
+          },
+          "extensions": {
+            "description": "List of extensions and their versions supported by the node.",
+            "items": {
+              "$ref": "#/components/schemas/envoy.config.core.v3.Extension"
+            },
+            "title": "extensions",
+            "type": "array"
+          },
+          "id": {
+            "description": "An opaque node identifier for the Envoy node. This also provides the local\n service node name. It should be set if any of the following features are\n used: :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`CDS\n \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-node`.",
+            "title": "id",
+            "type": "string"
+          },
+          "listeningAddresses": {
+            "deprecated": true,
+            "description": "Known listening ports on the node as a generic hint to the management server\n for filtering :ref:`listeners \u003cconfig_listeners\u003e` to be returned. For example,\n if there is a listener bound to port 80, the list can optionally contain the\n SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.",
+            "items": {
+              "$ref": "#/components/schemas/envoy.config.core.v3.Address"
+            },
+            "title": "listening_addresses",
+            "type": "array"
+          },
+          "locality": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/envoy.config.core.v3.Locality"
+              }
+            ],
+            "description": "Locality specifying where the Envoy instance is running.",
+            "title": "locality"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Struct"
+              }
+            ],
+            "description": "Opaque metadata extending the node identifier. Envoy will pass this\n directly to the management server.",
+            "title": "metadata"
+          },
+          "userAgentName": {
+            "description": "Free-form string that identifies the entity requesting config.\n E.g. \"envoy\" or \"grpc\"",
+            "title": "user_agent_name",
+            "type": "string"
+          }
+        },
         "title": "Node",
         "type": "object",
         "unevaluatedProperties": false
@@ -518,88 +518,94 @@
         "type": "object"
       },
       "envoy.config.core.v3.SocketAddress": {
-        "allOf": [
+        "anyOf": [
           {
             "properties": {
-              "address": {
-                "description": "The address for this socket. :ref:`Listeners \u003cconfig_listeners\u003e` will bind\n to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``\n to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:\n It is possible to distinguish a Listener address via the prefix/suffix matching\n in :ref:`FilterChainMatch \u003cenvoy_v3_api_msg_config.listener.v3.FilterChainMatch\u003e`.] When used\n within an upstream :ref:`BindConfig \u003cenvoy_v3_api_msg_config.core.v3.BindConfig\u003e`, the address\n controls the source address of outbound connections. For :ref:`clusters\n \u003cenvoy_v3_api_msg_config.cluster.v3.Cluster\u003e`, the cluster type determines whether the\n address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS\n (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized\n via :ref:`resolver_name \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e`.",
-                "title": "address",
-                "type": "string"
-              },
-              "ipv4Compat": {
-                "description": "When binding to an IPv6 address above, this enables `IPv4 compatibility\n \u003chttps://tools.ietf.org/html/rfc3493#page-11\u003e`_. Binding to ``::`` will\n allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into\n IPv6 space as ``::FFFF:\u003cIPv4-address\u003e``.",
-                "title": "ipv4_compat",
-                "type": "boolean"
-              },
-              "networkNamespaceFilepath": {
-                "description": "Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7\n network_namespaces``). If this field is set, Envoy will create the socket in the specified\n network namespace.\n\n .. note::\n    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.\n\n .. note::\n    Currently only used for Listener sockets.\n\n .. attention::\n     Network namespaces are only configurable on Linux. Otherwise, this field has no effect.",
-                "title": "network_namespace_filepath",
-                "type": "string"
-              },
-              "protocol": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol"
-                  }
-                ],
-                "title": "protocol"
-              },
-              "resolverName": {
-                "description": "The name of the custom resolver. This must have been registered with Envoy. If\n this is empty, a context dependent default applies. If the address is a concrete\n IP address, no resolution will occur. If address is a hostname this\n should be set for resolution other than DNS. Specifying a custom resolver with\n ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime.",
-                "title": "resolver_name",
+              "namedPort": {
+                "description": "This is only valid if :ref:`resolver_name\n \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e` is specified below and the\n named resolver is capable of named port resolution.",
+                "title": "named_port",
                 "type": "string"
               }
-            }
+            },
+            "title": "named_port",
+            "type": "object"
           },
           {
-            "oneOf": [
-              {
-                "properties": {
-                  "namedPort": {
-                    "description": "This is only valid if :ref:`resolver_name\n \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e` is specified below and the\n named resolver is capable of named port resolution.",
-                    "title": "named_port",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "namedPort"
-                ],
-                "title": "named_port",
-                "type": "object"
-              },
-              {
-                "properties": {
-                  "portValue": {
-                    "title": "port_value",
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "portValue"
-                ],
+            "properties": {
+              "portValue": {
                 "title": "port_value",
-                "type": "object"
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "namedPort"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "portValue"
-                      ]
-                    }
-                  ]
-                }
+                "type": "integer"
               }
-            ]
+            },
+            "title": "port_value",
+            "type": "object"
           }
         ],
         "description": "[#next-free-field: 8]",
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "namedPort"
+                  ]
+                },
+                {
+                  "required": [
+                    "portValue"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "namedPort"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "portValue"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "address": {
+            "description": "The address for this socket. :ref:`Listeners \u003cconfig_listeners\u003e` will bind\n to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``\n to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:\n It is possible to distinguish a Listener address via the prefix/suffix matching\n in :ref:`FilterChainMatch \u003cenvoy_v3_api_msg_config.listener.v3.FilterChainMatch\u003e`.] When used\n within an upstream :ref:`BindConfig \u003cenvoy_v3_api_msg_config.core.v3.BindConfig\u003e`, the address\n controls the source address of outbound connections. For :ref:`clusters\n \u003cenvoy_v3_api_msg_config.cluster.v3.Cluster\u003e`, the cluster type determines whether the\n address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS\n (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized\n via :ref:`resolver_name \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e`.",
+            "title": "address",
+            "type": "string"
+          },
+          "ipv4Compat": {
+            "description": "When binding to an IPv6 address above, this enables `IPv4 compatibility\n \u003chttps://tools.ietf.org/html/rfc3493#page-11\u003e`_. Binding to ``::`` will\n allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into\n IPv6 space as ``::FFFF:\u003cIPv4-address\u003e``.",
+            "title": "ipv4_compat",
+            "type": "boolean"
+          },
+          "networkNamespaceFilepath": {
+            "description": "Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7\n network_namespaces``). If this field is set, Envoy will create the socket in the specified\n network namespace.\n\n .. note::\n    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.\n\n .. note::\n    Currently only used for Listener sockets.\n\n .. attention::\n     Network namespaces are only configurable on Linux. Otherwise, this field has no effect.",
+            "title": "network_namespace_filepath",
+            "type": "string"
+          },
+          "protocol": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol"
+              }
+            ],
+            "title": "protocol"
+          },
+          "resolverName": {
+            "description": "The name of the custom resolver. This must have been registered with Envoy. If\n this is empty, a context dependent default applies. If the address is a concrete\n IP address, no resolution will occur. If address is a hostname this\n should be set for resolution other than DNS. Specifying a custom resolver with\n ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime.",
+            "title": "resolver_name",
+            "type": "string"
+          }
+        },
         "title": "SocketAddress",
         "type": "object",
         "unevaluatedProperties": false
@@ -864,8 +870,7 @@
         "type": "object"
       },
       "envoy.service.discovery.v3.DynamicParameterConstraints": {
-        "description": "A set of dynamic parameter constraints associated with a variant of an individual xDS resource.\n These constraints determine whether the resource matches a subscription based on the set of\n dynamic parameters in the subscription, as specified in the\n :ref:`ResourceLocator.dynamic_parameters \u003cenvoy_v3_api_field_service.discovery.v3.ResourceLocator.dynamic_parameters\u003e`\n field. This allows xDS implementations (clients, servers, and caching proxies) to determine\n which variant of a resource is appropriate for a given client.",
-        "oneOf": [
+        "anyOf": [
           {
             "properties": {
               "andConstraints": {
@@ -878,9 +883,6 @@
                 "title": "and_constraints"
               }
             },
-            "required": [
-              "andConstraints"
-            ],
             "title": "and_constraints",
             "type": "object"
           },
@@ -896,9 +898,6 @@
                 "title": "constraint"
               }
             },
-            "required": [
-              "constraint"
-            ],
             "title": "constraint",
             "type": "object"
           },
@@ -914,9 +913,6 @@
                 "title": "not_constraints"
               }
             },
-            "required": [
-              "notConstraints"
-            ],
             "title": "not_constraints",
             "type": "object"
           },
@@ -932,14 +928,14 @@
                 "title": "or_constraints"
               }
             },
-            "required": [
-              "orConstraints"
-            ],
             "title": "or_constraints",
             "type": "object"
-          },
-          {
-            "not": {
+          }
+        ],
+        "description": "A set of dynamic parameter constraints associated with a variant of an individual xDS resource.\n These constraints determine whether the resource matches a subscription based on the set of\n dynamic parameters in the subscription, as specified in the\n :ref:`ResourceLocator.dynamic_parameters \u003cenvoy_v3_api_field_service.discovery.v3.ResourceLocator.dynamic_parameters\u003e`\n field. This allows xDS implementations (clients, servers, and caching proxies) to determine\n which variant of a resource is appropriate for a given client.",
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -962,9 +958,35 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "andConstraints"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "constraint"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "notConstraints"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "orConstraints"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
+          ]
+        },
         "title": "DynamicParameterConstraints",
         "type": "object",
         "unevaluatedProperties": false
@@ -984,70 +1006,76 @@
         "type": "object"
       },
       "envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint": {
-        "allOf": [
+        "anyOf": [
           {
             "properties": {
-              "key": {
-                "description": "The key to match against.",
-                "title": "key",
-                "type": "string"
+              "exists": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists"
+                  }
+                ],
+                "description": "Key is present (matches any value except for the key being absent).\n This allows setting a default constraint for clients that do\n not send a key at all, while there may be other clients that need\n special configuration based on that key.",
+                "title": "exists"
               }
-            }
+            },
+            "title": "exists",
+            "type": "object"
           },
           {
-            "oneOf": [
-              {
-                "properties": {
-                  "exists": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists"
-                      }
-                    ],
-                    "description": "Key is present (matches any value except for the key being absent).\n This allows setting a default constraint for clients that do\n not send a key at all, while there may be other clients that need\n special configuration based on that key.",
-                    "title": "exists"
-                  }
-                },
-                "required": [
-                  "exists"
-                ],
-                "title": "exists",
-                "type": "object"
-              },
-              {
-                "properties": {
-                  "value": {
-                    "description": "Matches this exact value.",
-                    "title": "value",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ],
+            "properties": {
+              "value": {
+                "description": "Matches this exact value.",
                 "title": "value",
-                "type": "object"
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "exists"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "value"
-                      ]
-                    }
-                  ]
-                }
+                "type": "string"
               }
-            ]
+            },
+            "title": "value",
+            "type": "object"
           }
         ],
         "description": "A single constraint for a given key.",
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "exists"
+                  ]
+                },
+                {
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "exists"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "value"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "key": {
+            "description": "The key to match against.",
+            "title": "key",
+            "type": "string"
+          }
+        },
         "title": "SingleConstraint",
         "type": "object",
         "unevaluatedProperties": false

--- a/internal/converter/testdata/standard/output/envoy.asyncapi.yaml
+++ b/internal/converter/testdata/standard/output/envoy.asyncapi.yaml
@@ -61,11 +61,7 @@ operations:
 components:
     schemas:
         envoy.config.core.v3.Address:
-            description: |-
-                Addresses specify either a logical or physical address and port, which are
-                 used to tell Envoy where to bind/listen, connect to upstream and find
-                 management servers.
-            oneOf:
+            anyOf:
                 - properties:
                     envoyInternalAddress:
                         allOf:
@@ -74,8 +70,6 @@ components:
                             Specifies a user-space address handled by :ref:`internal listeners
                              <envoy_v3_api_field_config.listener.v3.Listener.internal_listener>`.
                         title: envoy_internal_address
-                  required:
-                    - envoyInternalAddress
                   title: envoy_internal_address
                   type: object
                 - properties:
@@ -83,8 +77,6 @@ components:
                         allOf:
                             - $ref: '#/components/schemas/envoy.config.core.v3.Pipe'
                         title: pipe
-                  required:
-                    - pipe
                   title: pipe
                   type: object
                 - properties:
@@ -92,18 +84,29 @@ components:
                         allOf:
                             - $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress'
                         title: socket_address
-                  required:
-                    - socketAddress
                   title: socket_address
                   type: object
-                - not:
-                    anyOf:
+            description: |-
+                Addresses specify either a logical or physical address and port, which are
+                 used to tell Envoy where to bind/listen, connect to upstream and find
+                 management servers.
+            not:
+                allOf:
+                    - anyOf:
                         - required:
                             - envoyInternalAddress
                         - required:
                             - pipe
                         - required:
                             - socketAddress
+                    - not:
+                        oneOf:
+                            - required:
+                                - envoyInternalAddress
+                            - required:
+                                - pipe
+                            - required:
+                                - socketAddress
             title: Address
             type: object
             unevaluatedProperties: false
@@ -141,34 +144,27 @@ components:
             title: ControlPlane
             type: object
         envoy.config.core.v3.EnvoyInternalAddress:
-            allOf:
+            anyOf:
                 - properties:
-                    endpointId:
+                    serverListenerName:
                         description: |-
-                            Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a
-                             single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for
-                             example, may be set to the final destination IP for the target internal listener.
-                        title: endpoint_id
+                            Specifies the :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the
+                             internal listener.
+                        title: server_listener_name
                         type: string
-                - oneOf:
-                    - properties:
-                        serverListenerName:
-                            description: |-
-                                Specifies the :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the
-                                 internal listener.
-                            title: server_listener_name
-                            type: string
-                      required:
-                        - serverListenerName
-                      title: server_listener_name
-                      type: object
-                    - not:
-                        anyOf:
-                            - required:
-                                - serverListenerName
+                  title: server_listener_name
+                  type: object
             description: |-
                 The address represents an envoy internal listener.
                  [#comment: TODO(asraa): When address available, remove workaround from test/server/server_fuzz_test.cc:30.]
+            properties:
+                endpointId:
+                    description: |-
+                        Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a
+                         single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for
+                         example, may be set to the final destination IP for the target internal listener.
+                    title: endpoint_id
+                    type: string
             title: EnvoyInternalAddress
             type: object
             unevaluatedProperties: false
@@ -307,126 +303,128 @@ components:
             title: Metadata
             type: object
         envoy.config.core.v3.Node:
-            allOf:
+            anyOf:
                 - properties:
-                    clientFeatures:
-                        description: |-
-                            Client feature support list. These are well known features described
-                             in the Envoy API repository for a given major version of an API. Client features
-                             use reverse DNS naming scheme, for example ``com.acme.feature``.
-                             See :ref:`the list of features <client_features>` that xDS client may
-                             support.
-                        items:
-                            type: string
-                        title: client_features
-                        type: array
-                    cluster:
-                        description: |-
-                            Defines the local service cluster name where Envoy is running. Though
-                             optional, it should be set if any of the following features are used:
-                             :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
-                             verification
-                             <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher>`,
-                             :ref:`runtime override directory <envoy_v3_api_msg_config.bootstrap.v3.Runtime>`,
-                             :ref:`user agent addition
-                             <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent>`,
-                             :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
-                             :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-                             <arch_overview_tracing>`, either in this message or via
-                             :option:`--service-cluster`.
-                        title: cluster
-                        type: string
-                    dynamicParameters:
-                        additionalProperties:
-                            allOf:
-                                - $ref: '#/components/schemas/xds.core.v3.ContextParams'
-                            title: value
-                        description: |-
-                            Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike
-                             other fields in this message). For example, the xDS client may have a shard identifier that
-                             changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the
-                             dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic
-                             parameter then appears in this field during future discovery requests.
-                        title: dynamic_parameters
-                        type: object
-                    extensions:
-                        description: List of extensions and their versions supported by the node.
-                        items:
-                            $ref: '#/components/schemas/envoy.config.core.v3.Extension'
-                        title: extensions
-                        type: array
-                    id:
-                        description: |-
-                            An opaque node identifier for the Envoy node. This also provides the local
-                             service node name. It should be set if any of the following features are
-                             used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
-                             <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-                             <arch_overview_tracing>`, either in this message or via
-                             :option:`--service-node`.
-                        title: id
-                        type: string
-                    listeningAddresses:
-                        deprecated: true
-                        description: |-
-                            Known listening ports on the node as a generic hint to the management server
-                             for filtering :ref:`listeners <config_listeners>` to be returned. For example,
-                             if there is a listener bound to port 80, the list can optionally contain the
-                             SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.
-                        items:
-                            $ref: '#/components/schemas/envoy.config.core.v3.Address'
-                        title: listening_addresses
-                        type: array
-                    locality:
+                    userAgentBuildVersion:
                         allOf:
-                            - $ref: '#/components/schemas/envoy.config.core.v3.Locality'
-                        description: Locality specifying where the Envoy instance is running.
-                        title: locality
-                    metadata:
-                        allOf:
-                            - $ref: '#/components/schemas/google.protobuf.Struct'
+                            - $ref: '#/components/schemas/envoy.config.core.v3.BuildVersion'
+                        description: Structured version of the entity requesting config.
+                        title: user_agent_build_version
+                  title: user_agent_build_version
+                  type: object
+                - properties:
+                    userAgentVersion:
                         description: |-
-                            Opaque metadata extending the node identifier. Envoy will pass this
-                             directly to the management server.
-                        title: metadata
-                    userAgentName:
-                        description: |-
-                            Free-form string that identifies the entity requesting config.
-                             E.g. "envoy" or "grpc"
-                        title: user_agent_name
+                            Free-form string that identifies the version of the entity requesting config.
+                             E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
+                        title: user_agent_version
                         type: string
-                - oneOf:
-                    - properties:
-                        userAgentBuildVersion:
-                            allOf:
-                                - $ref: '#/components/schemas/envoy.config.core.v3.BuildVersion'
-                            description: Structured version of the entity requesting config.
-                            title: user_agent_build_version
-                      required:
-                        - userAgentBuildVersion
-                      title: user_agent_build_version
-                      type: object
-                    - properties:
-                        userAgentVersion:
-                            description: |-
-                                Free-form string that identifies the version of the entity requesting config.
-                                 E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
-                            title: user_agent_version
-                            type: string
-                      required:
-                        - userAgentVersion
-                      title: user_agent_version
-                      type: object
-                    - not:
-                        anyOf:
-                            - required:
-                                - userAgentBuildVersion
-                            - required:
-                                - userAgentVersion
+                  title: user_agent_version
+                  type: object
             description: |-
                 Identifies a specific Envoy instance. The node identifier is presented to the
                  management server, which may use this identifier to distinguish per Envoy
                  configuration for serving.
                  [#next-free-field: 13]
+            not:
+                allOf:
+                    - anyOf:
+                        - required:
+                            - userAgentBuildVersion
+                        - required:
+                            - userAgentVersion
+                    - not:
+                        oneOf:
+                            - required:
+                                - userAgentBuildVersion
+                            - required:
+                                - userAgentVersion
+            properties:
+                clientFeatures:
+                    description: |-
+                        Client feature support list. These are well known features described
+                         in the Envoy API repository for a given major version of an API. Client features
+                         use reverse DNS naming scheme, for example ``com.acme.feature``.
+                         See :ref:`the list of features <client_features>` that xDS client may
+                         support.
+                    items:
+                        type: string
+                    title: client_features
+                    type: array
+                cluster:
+                    description: |-
+                        Defines the local service cluster name where Envoy is running. Though
+                         optional, it should be set if any of the following features are used:
+                         :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+                         verification
+                         <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher>`,
+                         :ref:`runtime override directory <envoy_v3_api_msg_config.bootstrap.v3.Runtime>`,
+                         :ref:`user agent addition
+                         <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent>`,
+                         :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+                         :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+                         <arch_overview_tracing>`, either in this message or via
+                         :option:`--service-cluster`.
+                    title: cluster
+                    type: string
+                dynamicParameters:
+                    additionalProperties:
+                        allOf:
+                            - $ref: '#/components/schemas/xds.core.v3.ContextParams'
+                        title: value
+                    description: |-
+                        Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike
+                         other fields in this message). For example, the xDS client may have a shard identifier that
+                         changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the
+                         dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic
+                         parameter then appears in this field during future discovery requests.
+                    title: dynamic_parameters
+                    type: object
+                extensions:
+                    description: List of extensions and their versions supported by the node.
+                    items:
+                        $ref: '#/components/schemas/envoy.config.core.v3.Extension'
+                    title: extensions
+                    type: array
+                id:
+                    description: |-
+                        An opaque node identifier for the Envoy node. This also provides the local
+                         service node name. It should be set if any of the following features are
+                         used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
+                         <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+                         <arch_overview_tracing>`, either in this message or via
+                         :option:`--service-node`.
+                    title: id
+                    type: string
+                listeningAddresses:
+                    deprecated: true
+                    description: |-
+                        Known listening ports on the node as a generic hint to the management server
+                         for filtering :ref:`listeners <config_listeners>` to be returned. For example,
+                         if there is a listener bound to port 80, the list can optionally contain the
+                         SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.
+                    items:
+                        $ref: '#/components/schemas/envoy.config.core.v3.Address'
+                    title: listening_addresses
+                    type: array
+                locality:
+                    allOf:
+                        - $ref: '#/components/schemas/envoy.config.core.v3.Locality'
+                    description: Locality specifying where the Envoy instance is running.
+                    title: locality
+                metadata:
+                    allOf:
+                        - $ref: '#/components/schemas/google.protobuf.Struct'
+                    description: |-
+                        Opaque metadata extending the node identifier. Envoy will pass this
+                         directly to the management server.
+                    title: metadata
+                userAgentName:
+                    description: |-
+                        Free-form string that identifies the entity requesting config.
+                         E.g. "envoy" or "grpc"
+                    title: user_agent_name
+                    type: string
             title: Node
             type: object
             unevaluatedProperties: false
@@ -448,88 +446,90 @@ components:
             title: Pipe
             type: object
         envoy.config.core.v3.SocketAddress:
-            allOf:
+            anyOf:
                 - properties:
-                    address:
+                    namedPort:
                         description: |-
-                            The address for this socket. :ref:`Listeners <config_listeners>` will bind
-                             to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
-                             to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
-                             It is possible to distinguish a Listener address via the prefix/suffix matching
-                             in :ref:`FilterChainMatch <envoy_v3_api_msg_config.listener.v3.FilterChainMatch>`.] When used
-                             within an upstream :ref:`BindConfig <envoy_v3_api_msg_config.core.v3.BindConfig>`, the address
-                             controls the source address of outbound connections. For :ref:`clusters
-                             <envoy_v3_api_msg_config.cluster.v3.Cluster>`, the cluster type determines whether the
-                             address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS
-                             (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized
-                             via :ref:`resolver_name <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`.
-                        title: address
+                            This is only valid if :ref:`resolver_name
+                             <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
+                             named resolver is capable of named port resolution.
+                        title: named_port
                         type: string
-                    ipv4Compat:
-                        description: |-
-                            When binding to an IPv6 address above, this enables `IPv4 compatibility
-                             <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
-                             allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
-                             IPv6 space as ``::FFFF:<IPv4-address>``.
-                        title: ipv4_compat
-                        type: boolean
-                    networkNamespaceFilepath:
-                        description: |-
-                            Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7
-                             network_namespaces``). If this field is set, Envoy will create the socket in the specified
-                             network namespace.
-
-                             .. note::
-                                Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.
-
-                             .. note::
-                                Currently only used for Listener sockets.
-
-                             .. attention::
-                                 Network namespaces are only configurable on Linux. Otherwise, this field has no effect.
-                        title: network_namespace_filepath
-                        type: string
-                    protocol:
-                        allOf:
-                            - $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol'
-                        title: protocol
-                    resolverName:
-                        description: |-
-                            The name of the custom resolver. This must have been registered with Envoy. If
-                             this is empty, a context dependent default applies. If the address is a concrete
-                             IP address, no resolution will occur. If address is a hostname this
-                             should be set for resolution other than DNS. Specifying a custom resolver with
-                             ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime.
-                        title: resolver_name
-                        type: string
-                - oneOf:
-                    - properties:
-                        namedPort:
-                            description: |-
-                                This is only valid if :ref:`resolver_name
-                                 <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
-                                 named resolver is capable of named port resolution.
-                            title: named_port
-                            type: string
-                      required:
-                        - namedPort
-                      title: named_port
-                      type: object
-                    - properties:
-                        portValue:
-                            title: port_value
-                            type: integer
-                      required:
-                        - portValue
-                      title: port_value
-                      type: object
+                  title: named_port
+                  type: object
+                - properties:
+                    portValue:
+                        title: port_value
+                        type: integer
+                  title: port_value
+                  type: object
+            description: '[#next-free-field: 8]'
+            not:
+                allOf:
+                    - anyOf:
+                        - required:
+                            - namedPort
+                        - required:
+                            - portValue
                     - not:
-                        anyOf:
+                        oneOf:
                             - required:
                                 - namedPort
                             - required:
                                 - portValue
-            description: '[#next-free-field: 8]'
+            properties:
+                address:
+                    description: |-
+                        The address for this socket. :ref:`Listeners <config_listeners>` will bind
+                         to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
+                         to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
+                         It is possible to distinguish a Listener address via the prefix/suffix matching
+                         in :ref:`FilterChainMatch <envoy_v3_api_msg_config.listener.v3.FilterChainMatch>`.] When used
+                         within an upstream :ref:`BindConfig <envoy_v3_api_msg_config.core.v3.BindConfig>`, the address
+                         controls the source address of outbound connections. For :ref:`clusters
+                         <envoy_v3_api_msg_config.cluster.v3.Cluster>`, the cluster type determines whether the
+                         address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS
+                         (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized
+                         via :ref:`resolver_name <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`.
+                    title: address
+                    type: string
+                ipv4Compat:
+                    description: |-
+                        When binding to an IPv6 address above, this enables `IPv4 compatibility
+                         <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
+                         allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
+                         IPv6 space as ``::FFFF:<IPv4-address>``.
+                    title: ipv4_compat
+                    type: boolean
+                networkNamespaceFilepath:
+                    description: |-
+                        Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7
+                         network_namespaces``). If this field is set, Envoy will create the socket in the specified
+                         network namespace.
+
+                         .. note::
+                            Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.
+
+                         .. note::
+                            Currently only used for Listener sockets.
+
+                         .. attention::
+                             Network namespaces are only configurable on Linux. Otherwise, this field has no effect.
+                    title: network_namespace_filepath
+                    type: string
+                protocol:
+                    allOf:
+                        - $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol'
+                    title: protocol
+                resolverName:
+                    description: |-
+                        The name of the custom resolver. This must have been registered with Envoy. If
+                         this is empty, a context dependent default applies. If the address is a concrete
+                         IP address, no resolution will occur. If address is a hostname this
+                         should be set for resolution other than DNS. Specifying a custom resolver with
+                         ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime.
+                    title: resolver_name
+                    type: string
             title: SocketAddress
             type: object
             unevaluatedProperties: false
@@ -906,22 +906,13 @@ components:
             title: DiscoveryResponse
             type: object
         envoy.service.discovery.v3.DynamicParameterConstraints:
-            description: |-
-                A set of dynamic parameter constraints associated with a variant of an individual xDS resource.
-                 These constraints determine whether the resource matches a subscription based on the set of
-                 dynamic parameters in the subscription, as specified in the
-                 :ref:`ResourceLocator.dynamic_parameters <envoy_v3_api_field_service.discovery.v3.ResourceLocator.dynamic_parameters>`
-                 field. This allows xDS implementations (clients, servers, and caching proxies) to determine
-                 which variant of a resource is appropriate for a given client.
-            oneOf:
+            anyOf:
                 - properties:
                     andConstraints:
                         allOf:
                             - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.ConstraintList'
                         description: A list of constraints that must all match.
                         title: and_constraints
-                  required:
-                    - andConstraints
                   title: and_constraints
                   type: object
                 - properties:
@@ -930,8 +921,6 @@ components:
                             - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint'
                         description: A single constraint to evaluate.
                         title: constraint
-                  required:
-                    - constraint
                   title: constraint
                   type: object
                 - properties:
@@ -940,8 +929,6 @@ components:
                             - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints'
                         description: The inverse (NOT) of a set of constraints.
                         title: not_constraints
-                  required:
-                    - notConstraints
                   title: not_constraints
                   type: object
                 - properties:
@@ -952,12 +939,18 @@ components:
                             A list of constraints that match if any one constraint in the list
                              matches.
                         title: or_constraints
-                  required:
-                    - orConstraints
                   title: or_constraints
                   type: object
-                - not:
-                    anyOf:
+            description: |-
+                A set of dynamic parameter constraints associated with a variant of an individual xDS resource.
+                 These constraints determine whether the resource matches a subscription based on the set of
+                 dynamic parameters in the subscription, as specified in the
+                 :ref:`ResourceLocator.dynamic_parameters <envoy_v3_api_field_service.discovery.v3.ResourceLocator.dynamic_parameters>`
+                 field. This allows xDS implementations (clients, servers, and caching proxies) to determine
+                 which variant of a resource is appropriate for a given client.
+            not:
+                allOf:
+                    - anyOf:
                         - required:
                             - andConstraints
                         - required:
@@ -966,6 +959,16 @@ components:
                             - notConstraints
                         - required:
                             - orConstraints
+                    - not:
+                        oneOf:
+                            - required:
+                                - andConstraints
+                            - required:
+                                - constraint
+                            - required:
+                                - notConstraints
+                            - required:
+                                - orConstraints
             title: DynamicParameterConstraints
             type: object
             unevaluatedProperties: false
@@ -980,43 +983,45 @@ components:
             title: ConstraintList
             type: object
         envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint:
-            allOf:
+            anyOf:
                 - properties:
-                    key:
-                        description: The key to match against.
-                        title: key
+                    exists:
+                        allOf:
+                            - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists'
+                        description: |-
+                            Key is present (matches any value except for the key being absent).
+                             This allows setting a default constraint for clients that do
+                             not send a key at all, while there may be other clients that need
+                             special configuration based on that key.
+                        title: exists
+                  title: exists
+                  type: object
+                - properties:
+                    value:
+                        description: Matches this exact value.
+                        title: value
                         type: string
-                - oneOf:
-                    - properties:
-                        exists:
-                            allOf:
-                                - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists'
-                            description: |-
-                                Key is present (matches any value except for the key being absent).
-                                 This allows setting a default constraint for clients that do
-                                 not send a key at all, while there may be other clients that need
-                                 special configuration based on that key.
-                            title: exists
-                      required:
-                        - exists
-                      title: exists
-                      type: object
-                    - properties:
-                        value:
-                            description: Matches this exact value.
-                            title: value
-                            type: string
-                      required:
-                        - value
-                      title: value
-                      type: object
+                  title: value
+                  type: object
+            description: A single constraint for a given key.
+            not:
+                allOf:
+                    - anyOf:
+                        - required:
+                            - exists
+                        - required:
+                            - value
                     - not:
-                        anyOf:
+                        oneOf:
                             - required:
                                 - exists
                             - required:
                                 - value
-            description: A single constraint for a given key.
+            properties:
+                key:
+                    description: The key to match against.
+                    title: key
+                    type: string
             title: SingleConstraint
             type: object
             unevaluatedProperties: false

--- a/internal/converter/testdata/standard/output/envoy.openapi.json
+++ b/internal/converter/testdata/standard/output/envoy.openapi.json
@@ -490,7 +490,7 @@
       },
       "envoy.config.core.v3.Address": {
         "type": "object",
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "properties": {
@@ -504,10 +504,7 @@
                 "description": "Specifies a user-space address handled by :ref:`internal listeners\n \u003cenvoy_v3_api_field_config.listener.v3.Listener.internal_listener\u003e`."
               }
             },
-            "title": "envoy_internal_address",
-            "required": [
-              "envoyInternalAddress"
-            ]
+            "title": "envoy_internal_address"
           },
           {
             "type": "object",
@@ -521,10 +518,7 @@
                 "title": "pipe"
               }
             },
-            "title": "pipe",
-            "required": [
-              "pipe"
-            ]
+            "title": "pipe"
           },
           {
             "type": "object",
@@ -538,13 +532,13 @@
                 "title": "socket_address"
               }
             },
-            "title": "socket_address",
-            "required": [
-              "socketAddress"
-            ]
-          },
-          {
-            "not": {
+            "title": "socket_address"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -562,10 +556,30 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "envoyInternalAddress"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "pipe"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "socketAddress"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
-        "unevaluatedProperties": false,
+          ]
+        },
         "title": "Address",
         "description": "Addresses specify either a logical or physical address and port, which are\n used to tell Envoy where to bind/listen, connect to upstream and find\n management servers."
       },
@@ -610,47 +624,27 @@
       },
       "envoy.config.core.v3.EnvoyInternalAddress": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "endpointId": {
+              "serverListenerName": {
                 "type": "string",
-                "title": "endpoint_id",
-                "description": "Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a\n single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for\n example, may be set to the final destination IP for the target internal listener."
-              }
-            }
-          },
-          {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "serverListenerName": {
-                    "type": "string",
-                    "title": "server_listener_name",
-                    "description": "Specifies the :ref:`name \u003cenvoy_v3_api_field_config.listener.v3.Listener.name\u003e` of the\n internal listener."
-                  }
-                },
                 "title": "server_listener_name",
-                "required": [
-                  "serverListenerName"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "serverListenerName"
-                      ]
-                    }
-                  ]
-                }
+                "description": "Specifies the :ref:`name \u003cenvoy_v3_api_field_config.listener.v3.Listener.name\u003e` of the\n internal listener."
               }
-            ]
+            },
+            "title": "server_listener_name"
           }
         ],
         "unevaluatedProperties": false,
+        "properties": {
+          "endpointId": {
+            "type": "string",
+            "title": "endpoint_id",
+            "description": "Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a\n single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for\n example, may be set to the final destination IP for the target internal listener."
+          }
+        },
         "title": "EnvoyInternalAddress",
         "description": "The address represents an envoy internal listener.\n [#comment: TODO(asraa): When address available, remove workaround from test/server/server_fuzz_test.cc:30.]"
       },
@@ -759,136 +753,142 @@
       },
       "envoy.config.core.v3.Node": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "id": {
-                "type": "string",
-                "title": "id",
-                "description": "An opaque node identifier for the Envoy node. This also provides the local\n service node name. It should be set if any of the following features are\n used: :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`CDS\n \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-node`."
-              },
-              "cluster": {
-                "type": "string",
-                "title": "cluster",
-                "description": "Defines the local service cluster name where Envoy is running. Though\n optional, it should be set if any of the following features are used:\n :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`health check cluster\n verification\n \u003cenvoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher\u003e`,\n :ref:`runtime override directory \u003cenvoy_v3_api_msg_config.bootstrap.v3.Runtime\u003e`,\n :ref:`user agent addition\n \u003cenvoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent\u003e`,\n :ref:`HTTP global rate limiting \u003cconfig_http_filters_rate_limit\u003e`,\n :ref:`CDS \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-cluster`."
-              },
-              "metadata": {
+              "userAgentBuildVersion": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/google.protobuf.Struct"
+                    "$ref": "#/components/schemas/envoy.config.core.v3.BuildVersion"
                   }
                 ],
-                "title": "metadata",
-                "description": "Opaque metadata extending the node identifier. Envoy will pass this\n directly to the management server."
-              },
-              "dynamicParameters": {
-                "type": "object",
-                "title": "dynamic_parameters",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/xds.core.v3.ContextParams"
-                    }
-                  ],
-                  "title": "value"
-                },
-                "description": "Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike\n other fields in this message). For example, the xDS client may have a shard identifier that\n changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the\n dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic\n parameter then appears in this field during future discovery requests."
-              },
-              "locality": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/envoy.config.core.v3.Locality"
-                  }
-                ],
-                "title": "locality",
-                "description": "Locality specifying where the Envoy instance is running."
-              },
-              "userAgentName": {
-                "type": "string",
-                "title": "user_agent_name",
-                "description": "Free-form string that identifies the entity requesting config.\n E.g. \"envoy\" or \"grpc\""
-              },
-              "extensions": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/envoy.config.core.v3.Extension"
-                },
-                "title": "extensions",
-                "description": "List of extensions and their versions supported by the node."
-              },
-              "clientFeatures": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "title": "client_features",
-                "description": "Client feature support list. These are well known features described\n in the Envoy API repository for a given major version of an API. Client features\n use reverse DNS naming scheme, for example ``com.acme.feature``.\n See :ref:`the list of features \u003cclient_features\u003e` that xDS client may\n support."
-              },
-              "listeningAddresses": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/envoy.config.core.v3.Address"
-                },
-                "title": "listening_addresses",
-                "description": "Known listening ports on the node as a generic hint to the management server\n for filtering :ref:`listeners \u003cconfig_listeners\u003e` to be returned. For example,\n if there is a listener bound to port 80, the list can optionally contain the\n SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.",
-                "deprecated": true
+                "title": "user_agent_build_version",
+                "description": "Structured version of the entity requesting config."
               }
-            }
+            },
+            "title": "user_agent_build_version"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "userAgentBuildVersion": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/envoy.config.core.v3.BuildVersion"
-                      }
-                    ],
-                    "title": "user_agent_build_version",
-                    "description": "Structured version of the entity requesting config."
-                  }
-                },
-                "title": "user_agent_build_version",
-                "required": [
-                  "userAgentBuildVersion"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "userAgentVersion": {
-                    "type": "string",
-                    "title": "user_agent_version",
-                    "description": "Free-form string that identifies the version of the entity requesting config.\n E.g. \"1.12.2\" or \"abcd1234\", or \"SpecialEnvoyBuild\""
-                  }
-                },
+            "type": "object",
+            "properties": {
+              "userAgentVersion": {
+                "type": "string",
                 "title": "user_agent_version",
-                "required": [
-                  "userAgentVersion"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "userAgentBuildVersion"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "userAgentVersion"
-                      ]
-                    }
-                  ]
-                }
+                "description": "Free-form string that identifies the version of the entity requesting config.\n E.g. \"1.12.2\" or \"abcd1234\", or \"SpecialEnvoyBuild\""
               }
-            ]
+            },
+            "title": "user_agent_version"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "userAgentBuildVersion"
+                  ]
+                },
+                {
+                  "required": [
+                    "userAgentVersion"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "userAgentBuildVersion"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "userAgentVersion"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "id",
+            "description": "An opaque node identifier for the Envoy node. This also provides the local\n service node name. It should be set if any of the following features are\n used: :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`CDS\n \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-node`."
+          },
+          "cluster": {
+            "type": "string",
+            "title": "cluster",
+            "description": "Defines the local service cluster name where Envoy is running. Though\n optional, it should be set if any of the following features are used:\n :ref:`statsd \u003carch_overview_statistics\u003e`, :ref:`health check cluster\n verification\n \u003cenvoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher\u003e`,\n :ref:`runtime override directory \u003cenvoy_v3_api_msg_config.bootstrap.v3.Runtime\u003e`,\n :ref:`user agent addition\n \u003cenvoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent\u003e`,\n :ref:`HTTP global rate limiting \u003cconfig_http_filters_rate_limit\u003e`,\n :ref:`CDS \u003cconfig_cluster_manager_cds\u003e`, and :ref:`HTTP tracing\n \u003carch_overview_tracing\u003e`, either in this message or via\n :option:`--service-cluster`."
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Struct"
+              }
+            ],
+            "title": "metadata",
+            "description": "Opaque metadata extending the node identifier. Envoy will pass this\n directly to the management server."
+          },
+          "dynamicParameters": {
+            "type": "object",
+            "title": "dynamic_parameters",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/xds.core.v3.ContextParams"
+                }
+              ],
+              "title": "value"
+            },
+            "description": "Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike\n other fields in this message). For example, the xDS client may have a shard identifier that\n changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the\n dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic\n parameter then appears in this field during future discovery requests."
+          },
+          "locality": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/envoy.config.core.v3.Locality"
+              }
+            ],
+            "title": "locality",
+            "description": "Locality specifying where the Envoy instance is running."
+          },
+          "userAgentName": {
+            "type": "string",
+            "title": "user_agent_name",
+            "description": "Free-form string that identifies the entity requesting config.\n E.g. \"envoy\" or \"grpc\""
+          },
+          "extensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/envoy.config.core.v3.Extension"
+            },
+            "title": "extensions",
+            "description": "List of extensions and their versions supported by the node."
+          },
+          "clientFeatures": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "client_features",
+            "description": "Client feature support list. These are well known features described\n in the Envoy API repository for a given major version of an API. Client features\n use reverse DNS naming scheme, for example ``com.acme.feature``.\n See :ref:`the list of features \u003cclient_features\u003e` that xDS client may\n support."
+          },
+          "listeningAddresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/envoy.config.core.v3.Address"
+            },
+            "title": "listening_addresses",
+            "description": "Known listening ports on the node as a generic hint to the management server\n for filtering :ref:`listeners \u003cconfig_listeners\u003e` to be returned. For example,\n if there is a listener bound to port 80, the list can optionally contain the\n SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.",
+            "deprecated": true
+          }
+        },
         "title": "Node",
         "description": "Identifies a specific Envoy instance. The node identifier is presented to the\n management server, which may use this identifier to distinguish per Envoy\n configuration for serving.\n [#next-free-field: 13]"
       },
@@ -911,88 +911,94 @@
       },
       "envoy.config.core.v3.SocketAddress": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "protocol": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol"
-                  }
-                ],
-                "title": "protocol"
-              },
-              "address": {
+              "namedPort": {
                 "type": "string",
-                "title": "address",
-                "description": "The address for this socket. :ref:`Listeners \u003cconfig_listeners\u003e` will bind\n to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``\n to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:\n It is possible to distinguish a Listener address via the prefix/suffix matching\n in :ref:`FilterChainMatch \u003cenvoy_v3_api_msg_config.listener.v3.FilterChainMatch\u003e`.] When used\n within an upstream :ref:`BindConfig \u003cenvoy_v3_api_msg_config.core.v3.BindConfig\u003e`, the address\n controls the source address of outbound connections. For :ref:`clusters\n \u003cenvoy_v3_api_msg_config.cluster.v3.Cluster\u003e`, the cluster type determines whether the\n address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS\n (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized\n via :ref:`resolver_name \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e`."
-              },
-              "resolverName": {
-                "type": "string",
-                "title": "resolver_name",
-                "description": "The name of the custom resolver. This must have been registered with Envoy. If\n this is empty, a context dependent default applies. If the address is a concrete\n IP address, no resolution will occur. If address is a hostname this\n should be set for resolution other than DNS. Specifying a custom resolver with\n ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime."
-              },
-              "ipv4Compat": {
-                "type": "boolean",
-                "title": "ipv4_compat",
-                "description": "When binding to an IPv6 address above, this enables `IPv4 compatibility\n \u003chttps://tools.ietf.org/html/rfc3493#page-11\u003e`_. Binding to ``::`` will\n allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into\n IPv6 space as ``::FFFF:\u003cIPv4-address\u003e``."
-              },
-              "networkNamespaceFilepath": {
-                "type": "string",
-                "title": "network_namespace_filepath",
-                "description": "Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7\n network_namespaces``). If this field is set, Envoy will create the socket in the specified\n network namespace.\n\n .. note::\n    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.\n\n .. note::\n    Currently only used for Listener sockets.\n\n .. attention::\n     Network namespaces are only configurable on Linux. Otherwise, this field has no effect."
+                "title": "named_port",
+                "description": "This is only valid if :ref:`resolver_name\n \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e` is specified below and the\n named resolver is capable of named port resolution."
               }
-            }
+            },
+            "title": "named_port"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "namedPort": {
-                    "type": "string",
-                    "title": "named_port",
-                    "description": "This is only valid if :ref:`resolver_name\n \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e` is specified below and the\n named resolver is capable of named port resolution."
-                  }
-                },
-                "title": "named_port",
-                "required": [
-                  "namedPort"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "portValue": {
-                    "type": "integer",
-                    "title": "port_value"
-                  }
-                },
-                "title": "port_value",
-                "required": [
-                  "portValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "namedPort"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "portValue"
-                      ]
-                    }
-                  ]
-                }
+            "type": "object",
+            "properties": {
+              "portValue": {
+                "type": "integer",
+                "title": "port_value"
               }
-            ]
+            },
+            "title": "port_value"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "namedPort"
+                  ]
+                },
+                {
+                  "required": [
+                    "portValue"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "namedPort"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "portValue"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "protocol": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol"
+              }
+            ],
+            "title": "protocol"
+          },
+          "address": {
+            "type": "string",
+            "title": "address",
+            "description": "The address for this socket. :ref:`Listeners \u003cconfig_listeners\u003e` will bind\n to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``\n to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:\n It is possible to distinguish a Listener address via the prefix/suffix matching\n in :ref:`FilterChainMatch \u003cenvoy_v3_api_msg_config.listener.v3.FilterChainMatch\u003e`.] When used\n within an upstream :ref:`BindConfig \u003cenvoy_v3_api_msg_config.core.v3.BindConfig\u003e`, the address\n controls the source address of outbound connections. For :ref:`clusters\n \u003cenvoy_v3_api_msg_config.cluster.v3.Cluster\u003e`, the cluster type determines whether the\n address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS\n (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized\n via :ref:`resolver_name \u003cenvoy_v3_api_field_config.core.v3.SocketAddress.resolver_name\u003e`."
+          },
+          "resolverName": {
+            "type": "string",
+            "title": "resolver_name",
+            "description": "The name of the custom resolver. This must have been registered with Envoy. If\n this is empty, a context dependent default applies. If the address is a concrete\n IP address, no resolution will occur. If address is a hostname this\n should be set for resolution other than DNS. Specifying a custom resolver with\n ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime."
+          },
+          "ipv4Compat": {
+            "type": "boolean",
+            "title": "ipv4_compat",
+            "description": "When binding to an IPv6 address above, this enables `IPv4 compatibility\n \u003chttps://tools.ietf.org/html/rfc3493#page-11\u003e`_. Binding to ``::`` will\n allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into\n IPv6 space as ``::FFFF:\u003cIPv4-address\u003e``."
+          },
+          "networkNamespaceFilepath": {
+            "type": "string",
+            "title": "network_namespace_filepath",
+            "description": "Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7\n network_namespaces``). If this field is set, Envoy will create the socket in the specified\n network namespace.\n\n .. note::\n    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.\n\n .. note::\n    Currently only used for Listener sockets.\n\n .. attention::\n     Network namespaces are only configurable on Linux. Otherwise, this field has no effect."
+          }
+        },
         "title": "SocketAddress",
         "description": "[#next-free-field: 8]"
       },
@@ -1257,7 +1263,7 @@
       },
       "envoy.service.discovery.v3.DynamicParameterConstraints": {
         "type": "object",
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "properties": {
@@ -1271,10 +1277,7 @@
                 "description": "A list of constraints that must all match."
               }
             },
-            "title": "and_constraints",
-            "required": [
-              "andConstraints"
-            ]
+            "title": "and_constraints"
           },
           {
             "type": "object",
@@ -1289,10 +1292,7 @@
                 "description": "A single constraint to evaluate."
               }
             },
-            "title": "constraint",
-            "required": [
-              "constraint"
-            ]
+            "title": "constraint"
           },
           {
             "type": "object",
@@ -1307,10 +1307,7 @@
                 "description": "The inverse (NOT) of a set of constraints."
               }
             },
-            "title": "not_constraints",
-            "required": [
-              "notConstraints"
-            ]
+            "title": "not_constraints"
           },
           {
             "type": "object",
@@ -1325,13 +1322,13 @@
                 "description": "A list of constraints that match if any one constraint in the list\n matches."
               }
             },
-            "title": "or_constraints",
-            "required": [
-              "orConstraints"
-            ]
-          },
-          {
-            "not": {
+            "title": "or_constraints"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -1354,10 +1351,35 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "andConstraints"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "constraint"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "notConstraints"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "orConstraints"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
-        "unevaluatedProperties": false,
+          ]
+        },
         "title": "DynamicParameterConstraints",
         "description": "A set of dynamic parameter constraints associated with a variant of an individual xDS resource.\n These constraints determine whether the resource matches a subscription based on the set of\n dynamic parameters in the subscription, as specified in the\n :ref:`ResourceLocator.dynamic_parameters \u003cenvoy_v3_api_field_service.discovery.v3.ResourceLocator.dynamic_parameters\u003e`\n field. This allows xDS implementations (clients, servers, and caching proxies) to determine\n which variant of a resource is appropriate for a given client."
       },
@@ -1377,70 +1399,76 @@
       },
       "envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "key": {
-                "type": "string",
-                "title": "key",
-                "description": "The key to match against."
+              "exists": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists"
+                  }
+                ],
+                "title": "exists",
+                "description": "Key is present (matches any value except for the key being absent).\n This allows setting a default constraint for clients that do\n not send a key at all, while there may be other clients that need\n special configuration based on that key."
               }
-            }
+            },
+            "title": "exists"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "exists": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists"
-                      }
-                    ],
-                    "title": "exists",
-                    "description": "Key is present (matches any value except for the key being absent).\n This allows setting a default constraint for clients that do\n not send a key at all, while there may be other clients that need\n special configuration based on that key."
-                  }
-                },
-                "title": "exists",
-                "required": [
-                  "exists"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "title": "value",
-                    "description": "Matches this exact value."
-                  }
-                },
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string",
                 "title": "value",
-                "required": [
-                  "value"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "exists"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "value"
-                      ]
-                    }
-                  ]
-                }
+                "description": "Matches this exact value."
               }
-            ]
+            },
+            "title": "value"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "exists"
+                  ]
+                },
+                {
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "exists"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "value"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "key",
+            "description": "The key to match against."
+          }
+        },
         "title": "SingleConstraint",
         "description": "A single constraint for a given key."
       },

--- a/internal/converter/testdata/standard/output/envoy.openapi.yaml
+++ b/internal/converter/testdata/standard/output/envoy.openapi.yaml
@@ -317,7 +317,7 @@ components:
       description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message, with an additional debug field for ConnectRPC error details.
     envoy.config.core.v3.Address:
       type: object
-      oneOf:
+      anyOf:
         - type: object
           properties:
             envoyInternalAddress:
@@ -328,8 +328,6 @@ components:
                 Specifies a user-space address handled by :ref:`internal listeners
                  <envoy_v3_api_field_config.listener.v3.Listener.internal_listener>`.
           title: envoy_internal_address
-          required:
-            - envoyInternalAddress
         - type: object
           properties:
             pipe:
@@ -337,8 +335,6 @@ components:
                 - $ref: '#/components/schemas/envoy.config.core.v3.Pipe'
               title: pipe
           title: pipe
-          required:
-            - pipe
         - type: object
           properties:
             socketAddress:
@@ -346,17 +342,24 @@ components:
                 - $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress'
               title: socket_address
           title: socket_address
-          required:
-            - socketAddress
-        - not:
-            anyOf:
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
               - required:
                   - envoyInternalAddress
               - required:
                   - pipe
               - required:
                   - socketAddress
-      unevaluatedProperties: false
+          - not:
+              oneOf:
+                - required:
+                    - envoyInternalAddress
+                - required:
+                    - pipe
+                - required:
+                    - socketAddress
       title: Address
       description: |-
         Addresses specify either a logical or physical address and port, which are
@@ -397,32 +400,25 @@ components:
       description: Identifies a specific ControlPlane instance that Envoy is connected to.
     envoy.config.core.v3.EnvoyInternalAddress:
       type: object
-      allOf:
-        - properties:
-            endpointId:
+      anyOf:
+        - type: object
+          properties:
+            serverListenerName:
               type: string
-              title: endpoint_id
-              description: |-
-                Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a
-                 single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for
-                 example, may be set to the final destination IP for the target internal listener.
-        - oneOf:
-            - type: object
-              properties:
-                serverListenerName:
-                  type: string
-                  title: server_listener_name
-                  description: |-
-                    Specifies the :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the
-                     internal listener.
               title: server_listener_name
-              required:
-                - serverListenerName
-            - not:
-                anyOf:
-                  - required:
-                      - serverListenerName
+              description: |-
+                Specifies the :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the
+                 internal listener.
+          title: server_listener_name
       unevaluatedProperties: false
+      properties:
+        endpointId:
+          type: string
+          title: endpoint_id
+          description: |-
+            Specifies an endpoint identifier to distinguish between multiple endpoints for the same internal listener in a
+             single upstream pool. Only used in the upstream addresses for tracking changes to individual endpoints. This, for
+             example, may be set to the final destination IP for the target internal listener.
       title: EnvoyInternalAddress
       description: |-
         The address represents an envoy internal listener.
@@ -563,122 +559,124 @@ components:
          [#next-major-version: move to type/metadata/v2]
     envoy.config.core.v3.Node:
       type: object
-      allOf:
-        - properties:
-            id:
-              type: string
-              title: id
-              description: |-
-                An opaque node identifier for the Envoy node. This also provides the local
-                 service node name. It should be set if any of the following features are
-                 used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
-                 <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-                 <arch_overview_tracing>`, either in this message or via
-                 :option:`--service-node`.
-            cluster:
-              type: string
-              title: cluster
-              description: |-
-                Defines the local service cluster name where Envoy is running. Though
-                 optional, it should be set if any of the following features are used:
-                 :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
-                 verification
-                 <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher>`,
-                 :ref:`runtime override directory <envoy_v3_api_msg_config.bootstrap.v3.Runtime>`,
-                 :ref:`user agent addition
-                 <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent>`,
-                 :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
-                 :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-                 <arch_overview_tracing>`, either in this message or via
-                 :option:`--service-cluster`.
-            metadata:
+      anyOf:
+        - type: object
+          properties:
+            userAgentBuildVersion:
               allOf:
-                - $ref: '#/components/schemas/google.protobuf.Struct'
-              title: metadata
-              description: |-
-                Opaque metadata extending the node identifier. Envoy will pass this
-                 directly to the management server.
-            dynamicParameters:
-              type: object
-              title: dynamic_parameters
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/xds.core.v3.ContextParams'
-                title: value
-              description: |-
-                Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike
-                 other fields in this message). For example, the xDS client may have a shard identifier that
-                 changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the
-                 dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic
-                 parameter then appears in this field during future discovery requests.
-            locality:
-              allOf:
-                - $ref: '#/components/schemas/envoy.config.core.v3.Locality'
-              title: locality
-              description: Locality specifying where the Envoy instance is running.
-            userAgentName:
-              type: string
-              title: user_agent_name
-              description: |-
-                Free-form string that identifies the entity requesting config.
-                 E.g. "envoy" or "grpc"
-            extensions:
-              type: array
-              items:
-                $ref: '#/components/schemas/envoy.config.core.v3.Extension'
-              title: extensions
-              description: List of extensions and their versions supported by the node.
-            clientFeatures:
-              type: array
-              items:
-                type: string
-              title: client_features
-              description: |-
-                Client feature support list. These are well known features described
-                 in the Envoy API repository for a given major version of an API. Client features
-                 use reverse DNS naming scheme, for example ``com.acme.feature``.
-                 See :ref:`the list of features <client_features>` that xDS client may
-                 support.
-            listeningAddresses:
-              type: array
-              items:
-                $ref: '#/components/schemas/envoy.config.core.v3.Address'
-              title: listening_addresses
-              description: |-
-                Known listening ports on the node as a generic hint to the management server
-                 for filtering :ref:`listeners <config_listeners>` to be returned. For example,
-                 if there is a listener bound to port 80, the list can optionally contain the
-                 SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.
-              deprecated: true
-        - oneOf:
-            - type: object
-              properties:
-                userAgentBuildVersion:
-                  allOf:
-                    - $ref: '#/components/schemas/envoy.config.core.v3.BuildVersion'
-                  title: user_agent_build_version
-                  description: Structured version of the entity requesting config.
+                - $ref: '#/components/schemas/envoy.config.core.v3.BuildVersion'
               title: user_agent_build_version
-              required:
-                - userAgentBuildVersion
-            - type: object
-              properties:
-                userAgentVersion:
-                  type: string
-                  title: user_agent_version
-                  description: |-
-                    Free-form string that identifies the version of the entity requesting config.
-                     E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
+              description: Structured version of the entity requesting config.
+          title: user_agent_build_version
+        - type: object
+          properties:
+            userAgentVersion:
+              type: string
               title: user_agent_version
-              required:
-                - userAgentVersion
-            - not:
-                anyOf:
-                  - required:
-                      - userAgentBuildVersion
-                  - required:
-                      - userAgentVersion
+              description: |-
+                Free-form string that identifies the version of the entity requesting config.
+                 E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
+          title: user_agent_version
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - userAgentBuildVersion
+              - required:
+                  - userAgentVersion
+          - not:
+              oneOf:
+                - required:
+                    - userAgentBuildVersion
+                - required:
+                    - userAgentVersion
+      properties:
+        id:
+          type: string
+          title: id
+          description: |-
+            An opaque node identifier for the Envoy node. This also provides the local
+             service node name. It should be set if any of the following features are
+             used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
+             <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+             <arch_overview_tracing>`, either in this message or via
+             :option:`--service-node`.
+        cluster:
+          type: string
+          title: cluster
+          description: |-
+            Defines the local service cluster name where Envoy is running. Though
+             optional, it should be set if any of the following features are used:
+             :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+             verification
+             <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.service_name_matcher>`,
+             :ref:`runtime override directory <envoy_v3_api_msg_config.bootstrap.v3.Runtime>`,
+             :ref:`user agent addition
+             <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.add_user_agent>`,
+             :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+             :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+             <arch_overview_tracing>`, either in this message or via
+             :option:`--service-cluster`.
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Struct'
+          title: metadata
+          description: |-
+            Opaque metadata extending the node identifier. Envoy will pass this
+             directly to the management server.
+        dynamicParameters:
+          type: object
+          title: dynamic_parameters
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/xds.core.v3.ContextParams'
+            title: value
+          description: |-
+            Map from xDS resource type URL to dynamic context parameters. These may vary at runtime (unlike
+             other fields in this message). For example, the xDS client may have a shard identifier that
+             changes during the lifetime of the xDS client. In Envoy, this would be achieved by updating the
+             dynamic context on the Server::Instance's LocalInfo context provider. The shard ID dynamic
+             parameter then appears in this field during future discovery requests.
+        locality:
+          allOf:
+            - $ref: '#/components/schemas/envoy.config.core.v3.Locality'
+          title: locality
+          description: Locality specifying where the Envoy instance is running.
+        userAgentName:
+          type: string
+          title: user_agent_name
+          description: |-
+            Free-form string that identifies the entity requesting config.
+             E.g. "envoy" or "grpc"
+        extensions:
+          type: array
+          items:
+            $ref: '#/components/schemas/envoy.config.core.v3.Extension'
+          title: extensions
+          description: List of extensions and their versions supported by the node.
+        clientFeatures:
+          type: array
+          items:
+            type: string
+          title: client_features
+          description: |-
+            Client feature support list. These are well known features described
+             in the Envoy API repository for a given major version of an API. Client features
+             use reverse DNS naming scheme, for example ``com.acme.feature``.
+             See :ref:`the list of features <client_features>` that xDS client may
+             support.
+        listeningAddresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/envoy.config.core.v3.Address'
+          title: listening_addresses
+          description: |-
+            Known listening ports on the node as a generic hint to the management server
+             for filtering :ref:`listeners <config_listeners>` to be returned. For example,
+             if there is a listener bound to port 80, the list can optionally contain the
+             SocketAddress ``(0.0.0.0,80)``. The field is optional and just a hint.
+          deprecated: true
       title: Node
       description: |-
         Identifies a specific Envoy instance. The node identifier is presented to the
@@ -704,88 +702,90 @@ components:
       additionalProperties: false
     envoy.config.core.v3.SocketAddress:
       type: object
-      allOf:
-        - properties:
-            protocol:
-              allOf:
-                - $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol'
-              title: protocol
-            address:
+      anyOf:
+        - type: object
+          properties:
+            namedPort:
               type: string
-              title: address
-              description: |-
-                The address for this socket. :ref:`Listeners <config_listeners>` will bind
-                 to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
-                 to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
-                 It is possible to distinguish a Listener address via the prefix/suffix matching
-                 in :ref:`FilterChainMatch <envoy_v3_api_msg_config.listener.v3.FilterChainMatch>`.] When used
-                 within an upstream :ref:`BindConfig <envoy_v3_api_msg_config.core.v3.BindConfig>`, the address
-                 controls the source address of outbound connections. For :ref:`clusters
-                 <envoy_v3_api_msg_config.cluster.v3.Cluster>`, the cluster type determines whether the
-                 address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS
-                 (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized
-                 via :ref:`resolver_name <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`.
-            resolverName:
-              type: string
-              title: resolver_name
-              description: |-
-                The name of the custom resolver. This must have been registered with Envoy. If
-                 this is empty, a context dependent default applies. If the address is a concrete
-                 IP address, no resolution will occur. If address is a hostname this
-                 should be set for resolution other than DNS. Specifying a custom resolver with
-                 ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime.
-            ipv4Compat:
-              type: boolean
-              title: ipv4_compat
-              description: |-
-                When binding to an IPv6 address above, this enables `IPv4 compatibility
-                 <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
-                 allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
-                 IPv6 space as ``::FFFF:<IPv4-address>``.
-            networkNamespaceFilepath:
-              type: string
-              title: network_namespace_filepath
-              description: |-
-                Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7
-                 network_namespaces``). If this field is set, Envoy will create the socket in the specified
-                 network namespace.
-
-                 .. note::
-                    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.
-
-                 .. note::
-                    Currently only used for Listener sockets.
-
-                 .. attention::
-                     Network namespaces are only configurable on Linux. Otherwise, this field has no effect.
-        - oneOf:
-            - type: object
-              properties:
-                namedPort:
-                  type: string
-                  title: named_port
-                  description: |-
-                    This is only valid if :ref:`resolver_name
-                     <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
-                     named resolver is capable of named port resolution.
               title: named_port
-              required:
-                - namedPort
-            - type: object
-              properties:
-                portValue:
-                  type: integer
-                  title: port_value
+              description: |-
+                This is only valid if :ref:`resolver_name
+                 <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>` is specified below and the
+                 named resolver is capable of named port resolution.
+          title: named_port
+        - type: object
+          properties:
+            portValue:
+              type: integer
               title: port_value
-              required:
-                - portValue
-            - not:
-                anyOf:
-                  - required:
-                      - namedPort
-                  - required:
-                      - portValue
+          title: port_value
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - namedPort
+              - required:
+                  - portValue
+          - not:
+              oneOf:
+                - required:
+                    - namedPort
+                - required:
+                    - portValue
+      properties:
+        protocol:
+          allOf:
+            - $ref: '#/components/schemas/envoy.config.core.v3.SocketAddress.Protocol'
+          title: protocol
+        address:
+          type: string
+          title: address
+          description: |-
+            The address for this socket. :ref:`Listeners <config_listeners>` will bind
+             to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
+             to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
+             It is possible to distinguish a Listener address via the prefix/suffix matching
+             in :ref:`FilterChainMatch <envoy_v3_api_msg_config.listener.v3.FilterChainMatch>`.] When used
+             within an upstream :ref:`BindConfig <envoy_v3_api_msg_config.core.v3.BindConfig>`, the address
+             controls the source address of outbound connections. For :ref:`clusters
+             <envoy_v3_api_msg_config.cluster.v3.Cluster>`, the cluster type determines whether the
+             address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS
+             (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized
+             via :ref:`resolver_name <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`.
+        resolverName:
+          type: string
+          title: resolver_name
+          description: |-
+            The name of the custom resolver. This must have been registered with Envoy. If
+             this is empty, a context dependent default applies. If the address is a concrete
+             IP address, no resolution will occur. If address is a hostname this
+             should be set for resolution other than DNS. Specifying a custom resolver with
+             ``STRICT_DNS`` or ``LOGICAL_DNS`` will generate an error at runtime.
+        ipv4Compat:
+          type: boolean
+          title: ipv4_compat
+          description: |-
+            When binding to an IPv6 address above, this enables `IPv4 compatibility
+             <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
+             allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
+             IPv6 space as ``::FFFF:<IPv4-address>``.
+        networkNamespaceFilepath:
+          type: string
+          title: network_namespace_filepath
+          description: |-
+            Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7
+             network_namespaces``). If this field is set, Envoy will create the socket in the specified
+             network namespace.
+
+             .. note::
+                Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.
+
+             .. note::
+                Currently only used for Listener sockets.
+
+             .. attention::
+                 Network namespaces are only configurable on Linux. Otherwise, this field has no effect.
       title: SocketAddress
       description: '[#next-free-field: 8]'
     envoy.config.core.v3.SocketAddress.Protocol:
@@ -1162,7 +1162,7 @@ components:
       description: '[#next-free-field: 8]'
     envoy.service.discovery.v3.DynamicParameterConstraints:
       type: object
-      oneOf:
+      anyOf:
         - type: object
           properties:
             andConstraints:
@@ -1171,8 +1171,6 @@ components:
               title: and_constraints
               description: A list of constraints that must all match.
           title: and_constraints
-          required:
-            - andConstraints
         - type: object
           properties:
             constraint:
@@ -1181,8 +1179,6 @@ components:
               title: constraint
               description: A single constraint to evaluate.
           title: constraint
-          required:
-            - constraint
         - type: object
           properties:
             notConstraints:
@@ -1191,8 +1187,6 @@ components:
               title: not_constraints
               description: The inverse (NOT) of a set of constraints.
           title: not_constraints
-          required:
-            - notConstraints
         - type: object
           properties:
             orConstraints:
@@ -1203,10 +1197,10 @@ components:
                 A list of constraints that match if any one constraint in the list
                  matches.
           title: or_constraints
-          required:
-            - orConstraints
-        - not:
-            anyOf:
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
               - required:
                   - andConstraints
               - required:
@@ -1215,7 +1209,16 @@ components:
                   - notConstraints
               - required:
                   - orConstraints
-      unevaluatedProperties: false
+          - not:
+              oneOf:
+                - required:
+                    - andConstraints
+                - required:
+                    - constraint
+                - required:
+                    - notConstraints
+                - required:
+                    - orConstraints
       title: DynamicParameterConstraints
       description: |-
         A set of dynamic parameter constraints associated with a variant of an individual xDS resource.
@@ -1236,43 +1239,45 @@ components:
       additionalProperties: false
     envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint:
       type: object
-      allOf:
-        - properties:
-            key:
-              type: string
-              title: key
-              description: The key to match against.
-        - oneOf:
-            - type: object
-              properties:
-                exists:
-                  allOf:
-                    - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists'
-                  title: exists
-                  description: |-
-                    Key is present (matches any value except for the key being absent).
-                     This allows setting a default constraint for clients that do
-                     not send a key at all, while there may be other clients that need
-                     special configuration based on that key.
+      anyOf:
+        - type: object
+          properties:
+            exists:
+              allOf:
+                - $ref: '#/components/schemas/envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists'
               title: exists
-              required:
-                - exists
-            - type: object
-              properties:
-                value:
-                  type: string
-                  title: value
-                  description: Matches this exact value.
+              description: |-
+                Key is present (matches any value except for the key being absent).
+                 This allows setting a default constraint for clients that do
+                 not send a key at all, while there may be other clients that need
+                 special configuration based on that key.
+          title: exists
+        - type: object
+          properties:
+            value:
+              type: string
               title: value
-              required:
-                - value
-            - not:
-                anyOf:
-                  - required:
-                      - exists
-                  - required:
-                      - value
+              description: Matches this exact value.
+          title: value
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - exists
+              - required:
+                  - value
+          - not:
+              oneOf:
+                - required:
+                    - exists
+                - required:
+                    - value
+      properties:
+        key:
+          type: string
+          title: key
+          description: The key to match against.
       title: SingleConstraint
       description: A single constraint for a given key.
     envoy.service.discovery.v3.DynamicParameterConstraints.SingleConstraint.Exists:

--- a/internal/converter/testdata/standard/output/oneof_interaction.openapi.json
+++ b/internal/converter/testdata/standard/output/oneof_interaction.openapi.json
@@ -162,69 +162,6 @@
         "type": "object",
         "allOf": [
           {
-            "properties": {
-              "c": {
-                "type": "string",
-                "title": "c"
-              },
-              "d": {
-                "type": "boolean",
-                "title": "d"
-              },
-              "e": {
-                "type": "string",
-                "title": "e"
-              }
-            }
-          },
-          {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "a": {
-                    "type": "string",
-                    "title": "a"
-                  }
-                },
-                "title": "a",
-                "required": [
-                  "a"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "b": {
-                    "type": "integer",
-                    "title": "b",
-                    "format": "int32"
-                  }
-                },
-                "title": "b",
-                "required": [
-                  "b"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "a"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "b"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
             "oneOf": [
               {
                 "required": [
@@ -239,7 +176,78 @@
             ]
           }
         ],
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "string",
+                "title": "a"
+              }
+            },
+            "title": "a"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "b": {
+                "type": "integer",
+                "title": "b",
+                "format": "int32"
+              }
+            },
+            "title": "b"
+          }
+        ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "a"
+                  ]
+                },
+                {
+                  "required": [
+                    "b"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "a"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "b"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "c": {
+            "type": "string",
+            "title": "c"
+          },
+          "d": {
+            "type": "boolean",
+            "title": "d"
+          },
+          "e": {
+            "type": "string",
+            "title": "e"
+          }
+        },
         "title": "OneofInteractionMessage"
       }
     }

--- a/internal/converter/testdata/standard/output/oneof_interaction.openapi.yaml
+++ b/internal/converter/testdata/standard/output/oneof_interaction.openapi.yaml
@@ -117,46 +117,49 @@ components:
     standard.OneofInteractionMessage:
       type: object
       allOf:
-        - properties:
-            c:
-              type: string
-              title: c
-            d:
-              type: boolean
-              title: d
-            e:
-              type: string
-              title: e
-        - oneOf:
-            - type: object
-              properties:
-                a:
-                  type: string
-                  title: a
-              title: a
-              required:
-                - a
-            - type: object
-              properties:
-                b:
-                  type: integer
-                  title: b
-                  format: int32
-              title: b
-              required:
-                - b
-            - not:
-                anyOf:
-                  - required:
-                      - a
-                  - required:
-                      - b
         - oneOf:
             - required:
                 - c
             - required:
                 - d
+      anyOf:
+        - type: object
+          properties:
+            a:
+              type: string
+              title: a
+          title: a
+        - type: object
+          properties:
+            b:
+              type: integer
+              title: b
+              format: int32
+          title: b
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - a
+              - required:
+                  - b
+          - not:
+              oneOf:
+                - required:
+                    - a
+                - required:
+                    - b
+      properties:
+        c:
+          type: string
+          title: c
+        d:
+          type: boolean
+          title: d
+        e:
+          type: string
+          title: e
       title: OneofInteractionMessage
 security: []
 tags:

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.json
@@ -328,7 +328,7 @@
             ]
           }
         ],
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "properties": {
@@ -338,10 +338,7 @@
                 "minLength": 1
               }
             },
-            "title": "a",
-            "required": [
-              "a"
-            ]
+            "title": "a"
           },
           {
             "type": "object",
@@ -351,13 +348,13 @@
                 "title": "b"
               }
             },
-            "title": "b",
-            "required": [
-              "b"
-            ]
-          },
-          {
-            "not": {
+            "title": "b"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -370,10 +367,25 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "a"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "b"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
-        "unevaluatedProperties": false,
+          ]
+        },
         "title": "CELMessage"
       },
       "protovalidate.LotsOfValidationRules": {
@@ -1868,7 +1880,7 @@
             ]
           }
         ],
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "properties": {
@@ -1878,10 +1890,7 @@
                 "minLength": 1
               }
             },
-            "title": "a",
-            "required": [
-              "a"
-            ]
+            "title": "a"
           },
           {
             "type": "object",
@@ -1891,13 +1900,13 @@
                 "title": "b"
               }
             },
-            "title": "b",
-            "required": [
-              "b"
-            ]
-          },
-          {
-            "not": {
+            "title": "b"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -1910,10 +1919,25 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "a"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "b"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
-        "unevaluatedProperties": false,
+          ]
+        },
         "title": "OneOfMessage"
       }
     }

--- a/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.openapi.yaml
@@ -224,7 +224,7 @@ components:
                 - a
             - required:
                 - b
-      oneOf:
+      anyOf:
         - type: object
           properties:
             a:
@@ -232,23 +232,26 @@ components:
               title: a
               minLength: 1
           title: a
-          required:
-            - a
         - type: object
           properties:
             b:
               type: string
               title: b
           title: b
-          required:
-            - b
-        - not:
-            anyOf:
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
               - required:
                   - a
               - required:
                   - b
-      unevaluatedProperties: false
+          - not:
+              oneOf:
+                - required:
+                    - a
+                - required:
+                    - b
       title: CELMessage
     protovalidate.LotsOfValidationRules:
       type: object
@@ -1437,7 +1440,7 @@ components:
                 - a
             - required:
                 - b
-      oneOf:
+      anyOf:
         - type: object
           properties:
             a:
@@ -1445,23 +1448,26 @@ components:
               title: a
               minLength: 1
           title: a
-          required:
-            - a
         - type: object
           properties:
             b:
               type: string
               title: b
           title: b
-          required:
-            - b
-        - not:
-            anyOf:
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
               - required:
                   - a
               - required:
                   - b
-      unevaluatedProperties: false
+          - not:
+              oneOf:
+                - required:
+                    - a
+                - required:
+                    - b
       title: OneOfMessage
 security: []
 tags:

--- a/internal/converter/testdata/standard/output/protovalidate.strings.openapi.json
+++ b/internal/converter/testdata/standard/output/protovalidate.strings.openapi.json
@@ -304,7 +304,7 @@
       },
       "buf.validate.conformance.cases.StringInOneof": {
         "type": "object",
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "properties": {
@@ -317,21 +317,7 @@
                 ]
               }
             },
-            "title": "bar",
-            "required": [
-              "bar"
-            ]
-          },
-          {
-            "not": {
-              "anyOf": [
-                {
-                  "required": [
-                    "bar"
-                  ]
-                }
-              ]
-            }
+            "title": "bar"
           }
         ],
         "unevaluatedProperties": false,

--- a/internal/converter/testdata/standard/output/protovalidate.strings.openapi.yaml
+++ b/internal/converter/testdata/standard/output/protovalidate.strings.openapi.yaml
@@ -258,7 +258,7 @@ components:
       additionalProperties: false
     buf.validate.conformance.cases.StringInOneof:
       type: object
-      oneOf:
+      anyOf:
         - type: object
           properties:
             bar:
@@ -268,12 +268,6 @@ components:
                 - a
                 - b
           title: bar
-          required:
-            - bar
-        - not:
-            anyOf:
-              - required:
-                  - bar
       unevaluatedProperties: false
       title: StringInOneof
     buf.validate.conformance.cases.StringLen:

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.json
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.json
@@ -827,7 +827,7 @@
       },
       "tensorflow.AttrValue": {
         "type": "object",
-        "oneOf": [
+        "anyOf": [
           {
             "type": "object",
             "properties": {
@@ -837,10 +837,7 @@
                 "description": "\"bool\""
               }
             },
-            "title": "b",
-            "required": [
-              "b"
-            ]
+            "title": "b"
           },
           {
             "type": "object",
@@ -852,10 +849,7 @@
                 "description": "\"float\""
               }
             },
-            "title": "f",
-            "required": [
-              "f"
-            ]
+            "title": "f"
           },
           {
             "type": "object",
@@ -870,10 +864,7 @@
                 "description": "\"func\" represents a function. func.name is a function's name or\n a primitive op's name. func.attr.first is the name of an attr\n defined for that function. func.attr.second is the value for\n that attr in the instantiation."
               }
             },
-            "title": "func",
-            "required": [
-              "func"
-            ]
+            "title": "func"
           },
           {
             "type": "object",
@@ -885,10 +876,7 @@
                 "description": "\"int\""
               }
             },
-            "title": "i",
-            "required": [
-              "i"
-            ]
+            "title": "i"
           },
           {
             "type": "object",
@@ -903,10 +891,7 @@
                 "description": "any \"list(...)\""
               }
             },
-            "title": "list",
-            "required": [
-              "list"
-            ]
+            "title": "list"
           },
           {
             "type": "object",
@@ -917,10 +902,7 @@
                 "description": "This is a placeholder only used in nodes defined inside a\n function.  It indicates the attr value will be supplied when\n the function is instantiated.  For example, let us suppose a\n node \"N\" in function \"FN\". \"N\" has an attr \"A\" with value\n placeholder = \"foo\". When FN is instantiated with attr \"foo\"\n set to \"bar\", the instantiated node N's attr A will have been\n given the value \"bar\"."
               }
             },
-            "title": "placeholder",
-            "required": [
-              "placeholder"
-            ]
+            "title": "placeholder"
           },
           {
             "type": "object",
@@ -932,10 +914,7 @@
                 "description": "\"string\""
               }
             },
-            "title": "s",
-            "required": [
-              "s"
-            ]
+            "title": "s"
           },
           {
             "type": "object",
@@ -950,10 +929,7 @@
                 "description": "\"shape\""
               }
             },
-            "title": "shape",
-            "required": [
-              "shape"
-            ]
+            "title": "shape"
           },
           {
             "type": "object",
@@ -968,10 +944,7 @@
                 "description": "\"tensor\""
               }
             },
-            "title": "tensor",
-            "required": [
-              "tensor"
-            ]
+            "title": "tensor"
           },
           {
             "type": "object",
@@ -986,13 +959,13 @@
                 "description": "\"type\""
               }
             },
-            "title": "type",
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "not": {
+            "title": "type"
+          }
+        ],
+        "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
               "anyOf": [
                 {
                   "required": [
@@ -1045,10 +1018,65 @@
                   ]
                 }
               ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "b"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "f"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "func"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "i"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "list"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "placeholder"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "s"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "shape"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "tensor"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "type"
+                    ]
+                  }
+                ]
+              }
             }
-          }
-        ],
-        "unevaluatedProperties": false,
+          ]
+        },
         "title": "AttrValue",
         "description": "Protocol buffer representing the value for an attr used to configure an Op.\n Comment indicates the corresponding attr type.  Only the field matching the\n attr type may be filled."
       },
@@ -2111,77 +2139,83 @@
       },
       "tensorflow.FullTypeDef": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "typeId": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/tensorflow.FullTypeId"
-                  }
-                ],
-                "title": "type_id",
-                "description": "The principal type represented by this object. This may be a concrete type\n (Tensor, Dataset) a type variable (used for dependent types) a type\n symbol (Any, Union). See FullTypeId for details."
-              },
-              "args": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/tensorflow.FullTypeDef"
-                },
-                "title": "args"
+              "i": {
+                "type": "string",
+                "title": "i",
+                "format": "int64",
+                "description": "TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc."
               }
-            }
+            },
+            "title": "i"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "i": {
-                    "type": "string",
-                    "title": "i",
-                    "format": "int64",
-                    "description": "TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc."
-                  }
-                },
-                "title": "i",
-                "required": [
-                  "i"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "s": {
-                    "type": "string",
-                    "title": "s"
-                  }
-                },
-                "title": "s",
-                "required": [
-                  "s"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "i"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "s"
-                      ]
-                    }
-                  ]
-                }
+            "type": "object",
+            "properties": {
+              "s": {
+                "type": "string",
+                "title": "s"
               }
-            ]
+            },
+            "title": "s"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "i"
+                  ]
+                },
+                {
+                  "required": [
+                    "s"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "i"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "s"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "typeId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/tensorflow.FullTypeId"
+              }
+            ],
+            "title": "type_id",
+            "description": "The principal type represented by this object. This may be a concrete type\n (Tensor, Dataset) a type variable (used for dependent types) a type\n symbol (Any, Union). See FullTypeId for details."
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/tensorflow.FullTypeDef"
+            },
+            "title": "args"
+          }
+        },
         "title": "FullTypeDef",
         "description": "Highly experimental and very likely to change.\n This encoding uses tags instead of dedicated messages for regularity. In\n particular the encoding imposes no restrictions on what the parameters of any\n type should be, which in particular needs to be true for type symbols."
       },

--- a/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
+++ b/internal/converter/testdata/standard/output/tensorflow.openapi.yaml
@@ -561,7 +561,7 @@ components:
       additionalProperties: false
     tensorflow.AttrValue:
       type: object
-      oneOf:
+      anyOf:
         - type: object
           properties:
             b:
@@ -569,8 +569,6 @@ components:
               title: b
               description: '"bool"'
           title: b
-          required:
-            - b
         - type: object
           properties:
             f:
@@ -579,8 +577,6 @@ components:
               format: float
               description: '"float"'
           title: f
-          required:
-            - f
         - type: object
           properties:
             func:
@@ -593,8 +589,6 @@ components:
                  defined for that function. func.attr.second is the value for
                  that attr in the instantiation.
           title: func
-          required:
-            - func
         - type: object
           properties:
             i:
@@ -603,8 +597,6 @@ components:
               format: int64
               description: '"int"'
           title: i
-          required:
-            - i
         - type: object
           properties:
             list:
@@ -613,8 +605,6 @@ components:
               title: list
               description: any "list(...)"
           title: list
-          required:
-            - list
         - type: object
           properties:
             placeholder:
@@ -629,8 +619,6 @@ components:
                  set to "bar", the instantiated node N's attr A will have been
                  given the value "bar".
           title: placeholder
-          required:
-            - placeholder
         - type: object
           properties:
             s:
@@ -639,8 +627,6 @@ components:
               format: byte
               description: '"string"'
           title: s
-          required:
-            - s
         - type: object
           properties:
             shape:
@@ -649,8 +635,6 @@ components:
               title: shape
               description: '"shape"'
           title: shape
-          required:
-            - shape
         - type: object
           properties:
             tensor:
@@ -659,8 +643,6 @@ components:
               title: tensor
               description: '"tensor"'
           title: tensor
-          required:
-            - tensor
         - type: object
           properties:
             type:
@@ -669,10 +651,10 @@ components:
               title: type
               description: '"type"'
           title: type
-          required:
-            - type
-        - not:
-            anyOf:
+      unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
               - required:
                   - b
               - required:
@@ -693,7 +675,28 @@ components:
                   - tensor
               - required:
                   - type
-      unevaluatedProperties: false
+          - not:
+              oneOf:
+                - required:
+                    - b
+                - required:
+                    - f
+                - required:
+                    - func
+                - required:
+                    - i
+                - required:
+                    - list
+                - required:
+                    - placeholder
+                - required:
+                    - s
+                - required:
+                    - shape
+                - required:
+                    - tensor
+                - required:
+                    - type
       title: AttrValue
       description: |-
         Protocol buffer representing the value for an attr used to configure an Op.
@@ -1856,47 +1859,49 @@ components:
       description: 'TODO(mrry): Return something about the operation?'
     tensorflow.FullTypeDef:
       type: object
-      allOf:
-        - properties:
-            typeId:
-              allOf:
-                - $ref: '#/components/schemas/tensorflow.FullTypeId'
-              title: type_id
-              description: |-
-                The principal type represented by this object. This may be a concrete type
-                 (Tensor, Dataset) a type variable (used for dependent types) a type
-                 symbol (Any, Union). See FullTypeId for details.
-            args:
-              type: array
-              items:
-                $ref: '#/components/schemas/tensorflow.FullTypeDef'
-              title: args
-        - oneOf:
-            - type: object
-              properties:
-                i:
-                  type: string
-                  title: i
-                  format: int64
-                  description: 'TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc.'
+      anyOf:
+        - type: object
+          properties:
+            i:
+              type: string
               title: i
-              required:
-                - i
-            - type: object
-              properties:
-                s:
-                  type: string
-                  title: s
+              format: int64
+              description: 'TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc.'
+          title: i
+        - type: object
+          properties:
+            s:
+              type: string
               title: s
-              required:
-                - s
-            - not:
-                anyOf:
-                  - required:
-                      - i
-                  - required:
-                      - s
+          title: s
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - i
+              - required:
+                  - s
+          - not:
+              oneOf:
+                - required:
+                    - i
+                - required:
+                    - s
+      properties:
+        typeId:
+          allOf:
+            - $ref: '#/components/schemas/tensorflow.FullTypeId'
+          title: type_id
+          description: |-
+            The principal type represented by this object. This may be a concrete type
+             (Tensor, Dataset) a type variable (used for dependent types) a type
+             symbol (Any, Union). See FullTypeId for details.
+        args:
+          type: array
+          items:
+            $ref: '#/components/schemas/tensorflow.FullTypeDef'
+          title: args
       title: FullTypeDef
       description: |-
         Highly experimental and very likely to change.

--- a/internal/converter/testdata/standard/output/test.openapi.json
+++ b/internal/converter/testdata/standard/output/test.openapi.json
@@ -139,963 +139,999 @@
       },
       "test.v1.AllTypes": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "doubleValue": {
-                "type": "number",
-                "title": "double_value",
-                "format": "double",
-                "description": "scalar types"
-              },
-              "floatValue": {
-                "type": "number",
-                "title": "float_value",
-                "format": "float"
-              },
-              "int32Value": {
-                "type": "integer",
-                "title": "int32_value",
-                "format": "int32"
-              },
-              "int64Value": {
-                "type": "string",
-                "title": "int64_value",
-                "format": "int64"
-              },
-              "uint32Value": {
-                "type": "integer",
-                "title": "uint32_value"
-              },
-              "uint64Value": {
-                "type": "string",
-                "title": "uint64_value",
-                "format": "int64"
-              },
-              "sint32Value": {
-                "type": "integer",
-                "title": "sint32_value",
-                "format": "int32"
-              },
-              "sint64Value": {
-                "type": "string",
-                "title": "sint64_value",
-                "format": "int64"
-              },
-              "fixed32Value": {
-                "type": "integer",
-                "title": "fixed32_value"
-              },
-              "fixed64Value": {
-                "type": "string",
-                "title": "fixed64_value",
-                "format": "int64"
-              },
-              "sfixed32Value": {
-                "type": "integer",
-                "title": "sfixed32_value",
-                "format": "int32"
-              },
-              "sfixed64Value": {
-                "type": "string",
-                "title": "sfixed64_value",
-                "format": "int64"
-              },
-              "boolValue": {
+              "boolOption": {
                 "type": "boolean",
-                "title": "bool_value"
-              },
-              "stringValue": {
-                "type": "string",
-                "title": "string_value"
-              },
-              "bytesValue": {
-                "type": "string",
-                "title": "bytes_value",
-                "format": "byte"
-              },
-              "doubleList": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "title": "double_list",
-                "description": "repeated types"
-              },
-              "floatList": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "float"
-                },
-                "title": "float_list"
-              },
-              "int32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "title": "int32_list"
-              },
-              "int64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "int64_list"
-              },
-              "uint32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                },
-                "title": "uint32_list"
-              },
-              "uint64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "uint64_list"
-              },
-              "sint32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "title": "sint32_list"
-              },
-              "sint64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "sint64_list"
-              },
-              "fixed32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                },
-                "title": "fixed32_list"
-              },
-              "fixed64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "fixed64_list"
-              },
-              "sfixed32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "title": "sfixed32_list"
-              },
-              "sfixed64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "sfixed64_list"
-              },
-              "boolList": {
-                "type": "array",
-                "items": {
-                  "type": "boolean"
-                },
-                "title": "bool_list"
-              },
-              "stringList": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "title": "string_list"
-              },
-              "bytesList": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "byte"
-                },
-                "title": "bytes_list"
-              },
-              "int32ToStringMap": {
-                "type": "object",
-                "title": "int32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                },
-                "description": "map key types"
-              },
-              "int64ToStringMap": {
-                "type": "object",
-                "title": "int64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "uint32ToStringMap": {
-                "type": "object",
-                "title": "uint32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "uint64ToStringMap": {
-                "type": "object",
-                "title": "uint64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "sint32ToStringMap": {
-                "type": "object",
-                "title": "sint32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "sint64ToStringMap": {
-                "type": "object",
-                "title": "sint64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "fixed32ToStringMap": {
-                "type": "object",
-                "title": "fixed32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "fixed64ToStringMap": {
-                "type": "object",
-                "title": "fixed64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "sfixed32ToStringMap": {
-                "type": "object",
-                "title": "sfixed32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "sfixed64ToStringMap": {
-                "type": "object",
-                "title": "sfixed64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "boolToStringMap": {
-                "type": "object",
-                "title": "bool_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "stringToStringMap": {
-                "type": "object",
-                "title": "string_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "doubleMap": {
-                "type": "object",
-                "title": "double_map",
-                "additionalProperties": {
-                  "type": "number",
-                  "title": "value",
-                  "format": "double"
-                },
-                "description": "map value types",
-                "deprecated": true
-              },
-              "floatMap": {
-                "type": "object",
-                "title": "float_map",
-                "additionalProperties": {
-                  "type": "number",
-                  "title": "value",
-                  "format": "float"
-                }
-              },
-              "int32Map": {
-                "type": "object",
-                "title": "int32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "format": "int32"
-                }
-              },
-              "int64Map": {
-                "type": "object",
-                "title": "int64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64"
-                }
-              },
-              "uint32Map": {
-                "type": "object",
-                "title": "uint32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value"
-                }
-              },
-              "uint64Map": {
-                "type": "object",
-                "title": "uint64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64"
-                }
-              },
-              "sint32Map": {
-                "type": "object",
-                "title": "sint32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "format": "int32"
-                }
-              },
-              "sint64Map": {
-                "type": "object",
-                "title": "sint64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64"
-                }
-              },
-              "fixed32Map": {
-                "type": "object",
-                "title": "fixed32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value"
-                }
-              },
-              "fixed64Map": {
-                "type": "object",
-                "title": "fixed64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64"
-                }
-              },
-              "sfixed32Map": {
-                "type": "object",
-                "title": "sfixed32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "format": "int32"
-                }
-              },
-              "sfixed64Map": {
-                "type": "object",
-                "title": "sfixed64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64"
-                }
-              },
-              "boolMap": {
-                "type": "object",
-                "title": "bool_map",
-                "additionalProperties": {
-                  "type": "boolean",
-                  "title": "value"
-                }
-              },
-              "stringMap": {
-                "type": "object",
-                "title": "string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                }
-              },
-              "bytesMap": {
-                "type": "object",
-                "title": "bytes_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "byte"
-                }
-              },
-              "optDoubleValue": {
-                "type": [
-                  "number",
-                  "null"
-                ],
-                "title": "opt_double_value",
-                "format": "double",
-                "description": "explicit presence types",
-                "deprecated": true
-              },
-              "optFloatValue": {
-                "type": [
-                  "number",
-                  "null"
-                ],
-                "title": "opt_float_value",
-                "format": "float"
-              },
-              "optInt32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_int32_value",
-                "format": "int32"
-              },
-              "optInt64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_int64_value",
-                "format": "int64"
-              },
-              "optUint32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_uint32_value"
-              },
-              "optUint64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_uint64_value",
-                "format": "int64"
-              },
-              "optSint32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_sint32_value",
-                "format": "int32"
-              },
-              "optSint64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_sint64_value",
-                "format": "int64"
-              },
-              "optFixed32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_fixed32_value"
-              },
-              "optFixed64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_fixed64_value",
-                "format": "int64"
-              },
-              "optSfixed32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_sfixed32_value",
-                "format": "int32"
-              },
-              "optSfixed64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_sfixed64_value",
-                "format": "int64"
-              },
-              "optBoolValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "title": "opt_bool_value"
-              },
-              "optStringValue": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_string_value"
-              },
-              "optBytesValue": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_bytes_value",
-                "format": "byte"
-              },
-              "msgValue": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/test.v1.AllTypes"
-                  }
-                ],
-                "title": "msg_value",
-                "deprecated": true
-              },
-              "enumValue": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
-                  }
-                ],
-                "title": "enum_value"
-              },
-              "optMsgValue": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/test.v1.AllTypes"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "opt_msg_value"
-              },
-              "optEnumValue": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "opt_enum_value"
-              },
-              "msgList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/test.v1.AllTypes"
-                },
-                "title": "msg_list"
-              },
-              "enumList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
-                },
-                "title": "enum_list"
-              },
-              "msgMap": {
-                "type": "object",
-                "title": "msg_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/test.v1.AllTypes"
-                    }
-                  ],
-                  "title": "value"
-                }
-              },
-              "enumMap": {
-                "type": "object",
-                "title": "enum_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
-                    }
-                  ],
-                  "title": "value"
-                }
+                "title": "bool_option"
               }
-            }
+            },
+            "title": "bool_option"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "boolOption": {
-                    "type": "boolean",
-                    "title": "bool_option"
-                  }
-                },
-                "title": "bool_option",
-                "required": [
-                  "boolOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "bytesOption": {
-                    "type": "string",
-                    "title": "bytes_option",
-                    "format": "byte"
-                  }
-                },
+            "type": "object",
+            "properties": {
+              "bytesOption": {
+                "type": "string",
                 "title": "bytes_option",
-                "required": [
-                  "bytesOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "doubleOption": {
-                    "type": "number",
-                    "title": "double_option",
-                    "format": "double",
-                    "deprecated": true
-                  }
-                },
-                "title": "double_option",
-                "required": [
-                  "doubleOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "enumOption": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
-                      }
-                    ],
-                    "title": "enum_option"
-                  }
-                },
-                "title": "enum_option",
-                "required": [
-                  "enumOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "fixed32Option": {
-                    "type": "integer",
-                    "title": "fixed32_option"
-                  }
-                },
-                "title": "fixed32_option",
-                "required": [
-                  "fixed32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "fixed64Option": {
-                    "type": "string",
-                    "title": "fixed64_option",
-                    "format": "int64"
-                  }
-                },
-                "title": "fixed64_option",
-                "required": [
-                  "fixed64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "floatOption": {
-                    "type": "number",
-                    "title": "float_option",
-                    "format": "float"
-                  }
-                },
-                "title": "float_option",
-                "required": [
-                  "floatOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "int32Option": {
-                    "type": "integer",
-                    "title": "int32_option",
-                    "format": "int32"
-                  }
-                },
-                "title": "int32_option",
-                "required": [
-                  "int32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "int64Option": {
-                    "type": "string",
-                    "title": "int64_option",
-                    "format": "int64"
-                  }
-                },
-                "title": "int64_option",
-                "required": [
-                  "int64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "msgOption": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/test.v1.AllTypes"
-                      }
-                    ],
-                    "title": "msg_option"
-                  }
-                },
-                "title": "msg_option",
-                "required": [
-                  "msgOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sfixed32Option": {
-                    "type": "integer",
-                    "title": "sfixed32_option",
-                    "format": "int32"
-                  }
-                },
-                "title": "sfixed32_option",
-                "required": [
-                  "sfixed32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sfixed64Option": {
-                    "type": "string",
-                    "title": "sfixed64_option",
-                    "format": "int64"
-                  }
-                },
-                "title": "sfixed64_option",
-                "required": [
-                  "sfixed64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sint32Option": {
-                    "type": "integer",
-                    "title": "sint32_option",
-                    "format": "int32"
-                  }
-                },
-                "title": "sint32_option",
-                "required": [
-                  "sint32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sint64Option": {
-                    "type": "string",
-                    "title": "sint64_option",
-                    "format": "int64"
-                  }
-                },
-                "title": "sint64_option",
-                "required": [
-                  "sint64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "stringOption": {
-                    "type": "string",
-                    "title": "string_option"
-                  }
-                },
-                "title": "string_option",
-                "required": [
-                  "stringOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "uint32Option": {
-                    "type": "integer",
-                    "title": "uint32_option"
-                  }
-                },
-                "title": "uint32_option",
-                "required": [
-                  "uint32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "uint64Option": {
-                    "type": "string",
-                    "title": "uint64_option",
-                    "format": "int64"
-                  }
-                },
-                "title": "uint64_option",
-                "required": [
-                  "uint64Option"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "boolOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bytesOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "doubleOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "enumOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "floatOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "msgOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "stringOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint64Option"
-                      ]
-                    }
-                  ]
-                }
+                "format": "byte"
               }
-            ]
+            },
+            "title": "bytes_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "doubleOption": {
+                "type": "number",
+                "title": "double_option",
+                "format": "double",
+                "deprecated": true
+              }
+            },
+            "title": "double_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "enumOption": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
+                  }
+                ],
+                "title": "enum_option"
+              }
+            },
+            "title": "enum_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "fixed32Option": {
+                "type": "integer",
+                "title": "fixed32_option"
+              }
+            },
+            "title": "fixed32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "fixed64Option": {
+                "type": "string",
+                "title": "fixed64_option",
+                "format": "int64"
+              }
+            },
+            "title": "fixed64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "floatOption": {
+                "type": "number",
+                "title": "float_option",
+                "format": "float"
+              }
+            },
+            "title": "float_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "int32Option": {
+                "type": "integer",
+                "title": "int32_option",
+                "format": "int32"
+              }
+            },
+            "title": "int32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "int64Option": {
+                "type": "string",
+                "title": "int64_option",
+                "format": "int64"
+              }
+            },
+            "title": "int64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "msgOption": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/test.v1.AllTypes"
+                  }
+                ],
+                "title": "msg_option"
+              }
+            },
+            "title": "msg_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sfixed32Option": {
+                "type": "integer",
+                "title": "sfixed32_option",
+                "format": "int32"
+              }
+            },
+            "title": "sfixed32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sfixed64Option": {
+                "type": "string",
+                "title": "sfixed64_option",
+                "format": "int64"
+              }
+            },
+            "title": "sfixed64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sint32Option": {
+                "type": "integer",
+                "title": "sint32_option",
+                "format": "int32"
+              }
+            },
+            "title": "sint32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sint64Option": {
+                "type": "string",
+                "title": "sint64_option",
+                "format": "int64"
+              }
+            },
+            "title": "sint64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "stringOption": {
+                "type": "string",
+                "title": "string_option"
+              }
+            },
+            "title": "string_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "uint32Option": {
+                "type": "integer",
+                "title": "uint32_option"
+              }
+            },
+            "title": "uint32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "uint64Option": {
+                "type": "string",
+                "title": "uint64_option",
+                "format": "int64"
+              }
+            },
+            "title": "uint64_option"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "boolOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "bytesOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "doubleOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "enumOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "floatOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "int32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "int64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "msgOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "stringOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint64Option"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "boolOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "bytesOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "doubleOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "enumOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fixed32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fixed64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "floatOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "int32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "int64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "msgOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sfixed32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sfixed64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sint32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sint64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "stringOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "uint32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "uint64Option"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "doubleValue": {
+            "type": "number",
+            "title": "double_value",
+            "format": "double",
+            "description": "scalar types"
+          },
+          "floatValue": {
+            "type": "number",
+            "title": "float_value",
+            "format": "float"
+          },
+          "int32Value": {
+            "type": "integer",
+            "title": "int32_value",
+            "format": "int32"
+          },
+          "int64Value": {
+            "type": "string",
+            "title": "int64_value",
+            "format": "int64"
+          },
+          "uint32Value": {
+            "type": "integer",
+            "title": "uint32_value"
+          },
+          "uint64Value": {
+            "type": "string",
+            "title": "uint64_value",
+            "format": "int64"
+          },
+          "sint32Value": {
+            "type": "integer",
+            "title": "sint32_value",
+            "format": "int32"
+          },
+          "sint64Value": {
+            "type": "string",
+            "title": "sint64_value",
+            "format": "int64"
+          },
+          "fixed32Value": {
+            "type": "integer",
+            "title": "fixed32_value"
+          },
+          "fixed64Value": {
+            "type": "string",
+            "title": "fixed64_value",
+            "format": "int64"
+          },
+          "sfixed32Value": {
+            "type": "integer",
+            "title": "sfixed32_value",
+            "format": "int32"
+          },
+          "sfixed64Value": {
+            "type": "string",
+            "title": "sfixed64_value",
+            "format": "int64"
+          },
+          "boolValue": {
+            "type": "boolean",
+            "title": "bool_value"
+          },
+          "stringValue": {
+            "type": "string",
+            "title": "string_value"
+          },
+          "bytesValue": {
+            "type": "string",
+            "title": "bytes_value",
+            "format": "byte"
+          },
+          "doubleList": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            },
+            "title": "double_list",
+            "description": "repeated types"
+          },
+          "floatList": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            },
+            "title": "float_list"
+          },
+          "int32List": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "title": "int32_list"
+          },
+          "int64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "int64_list"
+          },
+          "uint32List": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "title": "uint32_list"
+          },
+          "uint64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "uint64_list"
+          },
+          "sint32List": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "title": "sint32_list"
+          },
+          "sint64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "sint64_list"
+          },
+          "fixed32List": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "title": "fixed32_list"
+          },
+          "fixed64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "fixed64_list"
+          },
+          "sfixed32List": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "title": "sfixed32_list"
+          },
+          "sfixed64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "sfixed64_list"
+          },
+          "boolList": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            },
+            "title": "bool_list"
+          },
+          "stringList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "string_list"
+          },
+          "bytesList": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "byte"
+            },
+            "title": "bytes_list"
+          },
+          "int32ToStringMap": {
+            "type": "object",
+            "title": "int32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            },
+            "description": "map key types"
+          },
+          "int64ToStringMap": {
+            "type": "object",
+            "title": "int64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "uint32ToStringMap": {
+            "type": "object",
+            "title": "uint32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "uint64ToStringMap": {
+            "type": "object",
+            "title": "uint64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "sint32ToStringMap": {
+            "type": "object",
+            "title": "sint32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "sint64ToStringMap": {
+            "type": "object",
+            "title": "sint64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "fixed32ToStringMap": {
+            "type": "object",
+            "title": "fixed32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "fixed64ToStringMap": {
+            "type": "object",
+            "title": "fixed64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "sfixed32ToStringMap": {
+            "type": "object",
+            "title": "sfixed32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "sfixed64ToStringMap": {
+            "type": "object",
+            "title": "sfixed64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "boolToStringMap": {
+            "type": "object",
+            "title": "bool_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "stringToStringMap": {
+            "type": "object",
+            "title": "string_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "doubleMap": {
+            "type": "object",
+            "title": "double_map",
+            "additionalProperties": {
+              "type": "number",
+              "title": "value",
+              "format": "double"
+            },
+            "description": "map value types",
+            "deprecated": true
+          },
+          "floatMap": {
+            "type": "object",
+            "title": "float_map",
+            "additionalProperties": {
+              "type": "number",
+              "title": "value",
+              "format": "float"
+            }
+          },
+          "int32Map": {
+            "type": "object",
+            "title": "int32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "format": "int32"
+            }
+          },
+          "int64Map": {
+            "type": "object",
+            "title": "int64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64"
+            }
+          },
+          "uint32Map": {
+            "type": "object",
+            "title": "uint32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value"
+            }
+          },
+          "uint64Map": {
+            "type": "object",
+            "title": "uint64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64"
+            }
+          },
+          "sint32Map": {
+            "type": "object",
+            "title": "sint32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "format": "int32"
+            }
+          },
+          "sint64Map": {
+            "type": "object",
+            "title": "sint64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64"
+            }
+          },
+          "fixed32Map": {
+            "type": "object",
+            "title": "fixed32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value"
+            }
+          },
+          "fixed64Map": {
+            "type": "object",
+            "title": "fixed64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64"
+            }
+          },
+          "sfixed32Map": {
+            "type": "object",
+            "title": "sfixed32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "format": "int32"
+            }
+          },
+          "sfixed64Map": {
+            "type": "object",
+            "title": "sfixed64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64"
+            }
+          },
+          "boolMap": {
+            "type": "object",
+            "title": "bool_map",
+            "additionalProperties": {
+              "type": "boolean",
+              "title": "value"
+            }
+          },
+          "stringMap": {
+            "type": "object",
+            "title": "string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            }
+          },
+          "bytesMap": {
+            "type": "object",
+            "title": "bytes_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "byte"
+            }
+          },
+          "optDoubleValue": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "title": "opt_double_value",
+            "format": "double",
+            "description": "explicit presence types",
+            "deprecated": true
+          },
+          "optFloatValue": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "title": "opt_float_value",
+            "format": "float"
+          },
+          "optInt32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_int32_value",
+            "format": "int32"
+          },
+          "optInt64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_int64_value",
+            "format": "int64"
+          },
+          "optUint32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_uint32_value"
+          },
+          "optUint64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_uint64_value",
+            "format": "int64"
+          },
+          "optSint32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_sint32_value",
+            "format": "int32"
+          },
+          "optSint64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_sint64_value",
+            "format": "int64"
+          },
+          "optFixed32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_fixed32_value"
+          },
+          "optFixed64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_fixed64_value",
+            "format": "int64"
+          },
+          "optSfixed32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_sfixed32_value",
+            "format": "int32"
+          },
+          "optSfixed64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_sfixed64_value",
+            "format": "int64"
+          },
+          "optBoolValue": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "title": "opt_bool_value"
+          },
+          "optStringValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_string_value"
+          },
+          "optBytesValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_bytes_value",
+            "format": "byte"
+          },
+          "msgValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.AllTypes"
+              }
+            ],
+            "title": "msg_value",
+            "deprecated": true
+          },
+          "enumValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
+              }
+            ],
+            "title": "enum_value"
+          },
+          "optMsgValue": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.AllTypes"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "opt_msg_value"
+          },
+          "optEnumValue": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "opt_enum_value"
+          },
+          "msgList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/test.v1.AllTypes"
+            },
+            "title": "msg_list"
+          },
+          "enumList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
+            },
+            "title": "enum_list"
+          },
+          "msgMap": {
+            "type": "object",
+            "title": "msg_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/test.v1.AllTypes"
+                }
+              ],
+              "title": "value"
+            }
+          },
+          "enumMap": {
+            "type": "object",
+            "title": "enum_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/test.v1.AllTypes.Enum"
+                }
+              ],
+              "title": "value"
+            }
+          }
+        },
         "title": "AllTypes"
       },
       "test.v1.AllTypes.Enum": {
@@ -1110,371 +1146,379 @@
       },
       "test.v1.ParameterValues": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "doubleValue": {
+              "oneofDoubleValue": {
                 "type": "number",
-                "title": "double_value",
-                "format": "double",
-                "description": "scalar types"
-              },
-              "floatValue": {
-                "type": "number",
-                "title": "float_value",
-                "format": "float"
-              },
-              "int32Value": {
-                "type": "integer",
-                "title": "int32_value",
-                "format": "int32"
-              },
-              "int64Value": {
-                "type": "string",
-                "title": "int64_value",
-                "format": "int64"
-              },
-              "uint32Value": {
-                "type": "integer",
-                "title": "uint32_value"
-              },
-              "uint64Value": {
-                "type": "string",
-                "title": "uint64_value",
-                "format": "int64"
-              },
-              "sint32Value": {
-                "type": "integer",
-                "title": "sint32_value",
-                "format": "int32"
-              },
-              "sint64Value": {
-                "type": "string",
-                "title": "sint64_value",
-                "format": "int64"
-              },
-              "fixed32Value": {
-                "type": "integer",
-                "title": "fixed32_value"
-              },
-              "fixed64Value": {
-                "type": "string",
-                "title": "fixed64_value",
-                "format": "int64"
-              },
-              "sfixed32Value": {
-                "type": "integer",
-                "title": "sfixed32_value",
-                "format": "int32"
-              },
-              "sfixed64Value": {
-                "type": "string",
-                "title": "sfixed64_value",
-                "format": "int64"
-              },
-              "boolValue": {
-                "type": "boolean",
-                "title": "bool_value"
-              },
-              "stringValue": {
-                "type": "string",
-                "title": "string_value"
-              },
-              "bytesValue": {
-                "type": "string",
-                "title": "bytes_value",
-                "format": "byte"
-              },
-              "timestamp": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Timestamp"
-                  }
-                ],
-                "title": "timestamp",
-                "description": "scalar wrappers"
-              },
-              "duration": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Duration"
-                  }
-                ],
-                "title": "duration"
-              },
-              "boolValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.BoolValue"
-                  }
-                ],
-                "title": "bool_value_wrapper"
-              },
-              "int32ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Int32Value"
-                  }
-                ],
-                "title": "int32_value_wrapper"
-              },
-              "int64ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Int64Value"
-                  }
-                ],
-                "title": "int64_value_wrapper"
-              },
-              "uint32ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.UInt32Value"
-                  }
-                ],
-                "title": "uint32_value_wrapper"
-              },
-              "uint64ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.UInt64Value"
-                  }
-                ],
-                "title": "uint64_value_wrapper"
-              },
-              "floatValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.FloatValue"
-                  }
-                ],
-                "title": "float_value_wrapper"
-              },
-              "doubleValueWrapper": {
+                "title": "oneof_double_value",
+                "format": "double"
+              }
+            },
+            "title": "oneof_double_value"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "oneofDoubleValueWrapper": {
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/google.protobuf.DoubleValue"
                   }
                 ],
-                "title": "double_value_wrapper"
-              },
-              "bytesValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.BytesValue"
-                  }
-                ],
-                "title": "bytes_value_wrapper"
-              },
-              "stringValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.StringValue"
-                  }
-                ],
-                "title": "string_value_wrapper"
-              },
-              "fieldMask": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.FieldMask"
-                  }
-                ],
-                "title": "field_mask"
-              },
-              "enumValue": {
+                "title": "oneof_double_value_wrapper"
+              }
+            },
+            "title": "oneof_double_value_wrapper"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "oneofEnumValue": {
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
                   }
                 ],
-                "title": "enum_value"
-              },
-              "enumList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
-                },
-                "title": "enum_list",
-                "description": "complex types",
-                "deprecated": true
-              },
-              "doubleList": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "title": "double_list"
-              },
-              "doubleValueList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/google.protobuf.DoubleValue"
-                },
-                "title": "double_value_list"
-              },
-              "nested": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/test.v1.ParameterValues.Nested"
-                  }
-                ],
-                "title": "nested"
-              },
-              "recursive": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/test.v1.ParameterValues"
-                  }
-                ],
-                "title": "recursive"
-              },
-              "stringMap": {
-                "type": "object",
-                "title": "string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value"
-                },
-                "description": "unsupported"
-              },
-              "stringValueMap": {
-                "type": "object",
-                "title": "string_value_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/google.protobuf.StringValue"
-                    }
-                  ],
-                  "title": "value"
-                }
-              },
-              "enumMap": {
-                "type": "object",
-                "title": "enum_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
-                    }
-                  ],
-                  "title": "value"
-                }
-              },
-              "nestedMap": {
-                "type": "object",
-                "title": "nested_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/test.v1.ParameterValues.Nested"
-                    }
-                  ],
-                  "title": "value"
-                }
-              },
-              "structValue": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Struct"
-                  }
-                ],
-                "title": "struct_value"
-              },
-              "value": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Value"
-                  }
-                ],
-                "title": "value"
-              },
-              "recursiveList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/test.v1.ParameterValues"
-                },
-                "title": "recursive_list"
+                "title": "oneof_enum_value"
               }
-            }
-          },
-          {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "oneofDoubleValue": {
-                    "type": "number",
-                    "title": "oneof_double_value",
-                    "format": "double"
-                  }
-                },
-                "title": "oneof_double_value",
-                "required": [
-                  "oneofDoubleValue"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "oneofDoubleValueWrapper": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/google.protobuf.DoubleValue"
-                      }
-                    ],
-                    "title": "oneof_double_value_wrapper"
-                  }
-                },
-                "title": "oneof_double_value_wrapper",
-                "required": [
-                  "oneofDoubleValueWrapper"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "oneofEnumValue": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
-                      }
-                    ],
-                    "title": "oneof_enum_value"
-                  }
-                },
-                "title": "oneof_enum_value",
-                "required": [
-                  "oneofEnumValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "oneofDoubleValue"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "oneofDoubleValueWrapper"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "oneofEnumValue"
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
+            },
+            "title": "oneof_enum_value"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "oneofDoubleValue"
+                  ]
+                },
+                {
+                  "required": [
+                    "oneofDoubleValueWrapper"
+                  ]
+                },
+                {
+                  "required": [
+                    "oneofEnumValue"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "oneofDoubleValue"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "oneofDoubleValueWrapper"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "oneofEnumValue"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "doubleValue": {
+            "type": "number",
+            "title": "double_value",
+            "format": "double",
+            "description": "scalar types"
+          },
+          "floatValue": {
+            "type": "number",
+            "title": "float_value",
+            "format": "float"
+          },
+          "int32Value": {
+            "type": "integer",
+            "title": "int32_value",
+            "format": "int32"
+          },
+          "int64Value": {
+            "type": "string",
+            "title": "int64_value",
+            "format": "int64"
+          },
+          "uint32Value": {
+            "type": "integer",
+            "title": "uint32_value"
+          },
+          "uint64Value": {
+            "type": "string",
+            "title": "uint64_value",
+            "format": "int64"
+          },
+          "sint32Value": {
+            "type": "integer",
+            "title": "sint32_value",
+            "format": "int32"
+          },
+          "sint64Value": {
+            "type": "string",
+            "title": "sint64_value",
+            "format": "int64"
+          },
+          "fixed32Value": {
+            "type": "integer",
+            "title": "fixed32_value"
+          },
+          "fixed64Value": {
+            "type": "string",
+            "title": "fixed64_value",
+            "format": "int64"
+          },
+          "sfixed32Value": {
+            "type": "integer",
+            "title": "sfixed32_value",
+            "format": "int32"
+          },
+          "sfixed64Value": {
+            "type": "string",
+            "title": "sfixed64_value",
+            "format": "int64"
+          },
+          "boolValue": {
+            "type": "boolean",
+            "title": "bool_value"
+          },
+          "stringValue": {
+            "type": "string",
+            "title": "string_value"
+          },
+          "bytesValue": {
+            "type": "string",
+            "title": "bytes_value",
+            "format": "byte"
+          },
+          "timestamp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Timestamp"
+              }
+            ],
+            "title": "timestamp",
+            "description": "scalar wrappers"
+          },
+          "duration": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Duration"
+              }
+            ],
+            "title": "duration"
+          },
+          "boolValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.BoolValue"
+              }
+            ],
+            "title": "bool_value_wrapper"
+          },
+          "int32ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Int32Value"
+              }
+            ],
+            "title": "int32_value_wrapper"
+          },
+          "int64ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Int64Value"
+              }
+            ],
+            "title": "int64_value_wrapper"
+          },
+          "uint32ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.UInt32Value"
+              }
+            ],
+            "title": "uint32_value_wrapper"
+          },
+          "uint64ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.UInt64Value"
+              }
+            ],
+            "title": "uint64_value_wrapper"
+          },
+          "floatValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.FloatValue"
+              }
+            ],
+            "title": "float_value_wrapper"
+          },
+          "doubleValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.DoubleValue"
+              }
+            ],
+            "title": "double_value_wrapper"
+          },
+          "bytesValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.BytesValue"
+              }
+            ],
+            "title": "bytes_value_wrapper"
+          },
+          "stringValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.StringValue"
+              }
+            ],
+            "title": "string_value_wrapper"
+          },
+          "fieldMask": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.FieldMask"
+              }
+            ],
+            "title": "field_mask"
+          },
+          "enumValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
+              }
+            ],
+            "title": "enum_value"
+          },
+          "enumList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
+            },
+            "title": "enum_list",
+            "description": "complex types",
+            "deprecated": true
+          },
+          "doubleList": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            },
+            "title": "double_list"
+          },
+          "doubleValueList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/google.protobuf.DoubleValue"
+            },
+            "title": "double_value_list"
+          },
+          "nested": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.ParameterValues.Nested"
+              }
+            ],
+            "title": "nested"
+          },
+          "recursive": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/test.v1.ParameterValues"
+              }
+            ],
+            "title": "recursive"
+          },
+          "stringMap": {
+            "type": "object",
+            "title": "string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value"
+            },
+            "description": "unsupported"
+          },
+          "stringValueMap": {
+            "type": "object",
+            "title": "string_value_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/google.protobuf.StringValue"
+                }
+              ],
+              "title": "value"
+            }
+          },
+          "enumMap": {
+            "type": "object",
+            "title": "enum_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/test.v1.ParameterValues.Enum"
+                }
+              ],
+              "title": "value"
+            }
+          },
+          "nestedMap": {
+            "type": "object",
+            "title": "nested_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/test.v1.ParameterValues.Nested"
+                }
+              ],
+              "title": "value"
+            }
+          },
+          "structValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Struct"
+              }
+            ],
+            "title": "struct_value"
+          },
+          "value": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Value"
+              }
+            ],
+            "title": "value"
+          },
+          "recursiveList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/test.v1.ParameterValues"
+            },
+            "title": "recursive_list"
+          }
+        },
         "title": "ParameterValues"
       },
       "test.v1.ParameterValues.Enum": {

--- a/internal/converter/testdata/standard/output/test.openapi.yaml
+++ b/internal/converter/testdata/standard/output/test.openapi.yaml
@@ -88,647 +88,649 @@ components:
       description: 'Any JSON value: `null`, number, string, boolean, array, or object.'
     test.v1.AllTypes:
       type: object
-      allOf:
-        - properties:
-            doubleValue:
-              type: number
-              title: double_value
-              format: double
-              description: scalar types
-            floatValue:
-              type: number
-              title: float_value
-              format: float
-            int32Value:
-              type: integer
-              title: int32_value
-              format: int32
-            int64Value:
-              type: string
-              title: int64_value
-              format: int64
-            uint32Value:
-              type: integer
-              title: uint32_value
-            uint64Value:
-              type: string
-              title: uint64_value
-              format: int64
-            sint32Value:
-              type: integer
-              title: sint32_value
-              format: int32
-            sint64Value:
-              type: string
-              title: sint64_value
-              format: int64
-            fixed32Value:
-              type: integer
-              title: fixed32_value
-            fixed64Value:
-              type: string
-              title: fixed64_value
-              format: int64
-            sfixed32Value:
-              type: integer
-              title: sfixed32_value
-              format: int32
-            sfixed64Value:
-              type: string
-              title: sfixed64_value
-              format: int64
-            boolValue:
+      anyOf:
+        - type: object
+          properties:
+            boolOption:
               type: boolean
-              title: bool_value
-            stringValue:
-              type: string
-              title: string_value
-            bytesValue:
-              type: string
-              title: bytes_value
-              format: byte
-            doubleList:
-              type: array
-              items:
-                type: number
-                format: double
-              title: double_list
-              description: repeated types
-            floatList:
-              type: array
-              items:
-                type: number
-                format: float
-              title: float_list
-            int32List:
-              type: array
-              items:
-                type: integer
-                format: int32
-              title: int32_list
-            int64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: int64_list
-            uint32List:
-              type: array
-              items:
-                type: integer
-              title: uint32_list
-            uint64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: uint64_list
-            sint32List:
-              type: array
-              items:
-                type: integer
-                format: int32
-              title: sint32_list
-            sint64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: sint64_list
-            fixed32List:
-              type: array
-              items:
-                type: integer
-              title: fixed32_list
-            fixed64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: fixed64_list
-            sfixed32List:
-              type: array
-              items:
-                type: integer
-                format: int32
-              title: sfixed32_list
-            sfixed64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: sfixed64_list
-            boolList:
-              type: array
-              items:
-                type: boolean
-              title: bool_list
-            stringList:
-              type: array
-              items:
-                type: string
-              title: string_list
-            bytesList:
-              type: array
-              items:
-                type: string
-                format: byte
-              title: bytes_list
-            int32ToStringMap:
-              type: object
-              title: int32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-              description: map key types
-            int64ToStringMap:
-              type: object
-              title: int64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            uint32ToStringMap:
-              type: object
-              title: uint32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            uint64ToStringMap:
-              type: object
-              title: uint64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            sint32ToStringMap:
-              type: object
-              title: sint32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            sint64ToStringMap:
-              type: object
-              title: sint64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            fixed32ToStringMap:
-              type: object
-              title: fixed32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            fixed64ToStringMap:
-              type: object
-              title: fixed64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            sfixed32ToStringMap:
-              type: object
-              title: sfixed32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            sfixed64ToStringMap:
-              type: object
-              title: sfixed64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            boolToStringMap:
-              type: object
-              title: bool_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            stringToStringMap:
-              type: object
-              title: string_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-            doubleMap:
-              type: object
-              title: double_map
-              additionalProperties:
-                type: number
-                title: value
-                format: double
-              description: map value types
-              deprecated: true
-            floatMap:
-              type: object
-              title: float_map
-              additionalProperties:
-                type: number
-                title: value
-                format: float
-            int32Map:
-              type: object
-              title: int32_map
-              additionalProperties:
-                type: integer
-                title: value
-                format: int32
-            int64Map:
-              type: object
-              title: int64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-            uint32Map:
-              type: object
-              title: uint32_map
-              additionalProperties:
-                type: integer
-                title: value
-            uint64Map:
-              type: object
-              title: uint64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-            sint32Map:
-              type: object
-              title: sint32_map
-              additionalProperties:
-                type: integer
-                title: value
-                format: int32
-            sint64Map:
-              type: object
-              title: sint64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-            fixed32Map:
-              type: object
-              title: fixed32_map
-              additionalProperties:
-                type: integer
-                title: value
-            fixed64Map:
-              type: object
-              title: fixed64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-            sfixed32Map:
-              type: object
-              title: sfixed32_map
-              additionalProperties:
-                type: integer
-                title: value
-                format: int32
-            sfixed64Map:
-              type: object
-              title: sfixed64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-            boolMap:
-              type: object
-              title: bool_map
-              additionalProperties:
-                type: boolean
-                title: value
-            stringMap:
-              type: object
-              title: string_map
-              additionalProperties:
-                type: string
-                title: value
-            bytesMap:
-              type: object
-              title: bytes_map
-              additionalProperties:
-                type: string
-                title: value
-                format: byte
-            optDoubleValue:
-              type:
-                - number
-                - "null"
-              title: opt_double_value
-              format: double
-              description: explicit presence types
-              deprecated: true
-            optFloatValue:
-              type:
-                - number
-                - "null"
-              title: opt_float_value
-              format: float
-            optInt32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_int32_value
-              format: int32
-            optInt64Value:
-              type:
-                - string
-                - "null"
-              title: opt_int64_value
-              format: int64
-            optUint32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_uint32_value
-            optUint64Value:
-              type:
-                - string
-                - "null"
-              title: opt_uint64_value
-              format: int64
-            optSint32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_sint32_value
-              format: int32
-            optSint64Value:
-              type:
-                - string
-                - "null"
-              title: opt_sint64_value
-              format: int64
-            optFixed32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_fixed32_value
-            optFixed64Value:
-              type:
-                - string
-                - "null"
-              title: opt_fixed64_value
-              format: int64
-            optSfixed32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_sfixed32_value
-              format: int32
-            optSfixed64Value:
-              type:
-                - string
-                - "null"
-              title: opt_sfixed64_value
-              format: int64
-            optBoolValue:
-              type:
-                - boolean
-                - "null"
-              title: opt_bool_value
-            optStringValue:
-              type:
-                - string
-                - "null"
-              title: opt_string_value
-            optBytesValue:
-              type:
-                - string
-                - "null"
-              title: opt_bytes_value
-              format: byte
-            msgValue:
-              allOf:
-                - $ref: '#/components/schemas/test.v1.AllTypes'
-              title: msg_value
-              deprecated: true
-            enumValue:
-              allOf:
-                - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
-              title: enum_value
-            optMsgValue:
-              oneOf:
-                - $ref: '#/components/schemas/test.v1.AllTypes'
-                - type: "null"
-              title: opt_msg_value
-            optEnumValue:
-              oneOf:
-                - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
-                - type: "null"
-              title: opt_enum_value
-            msgList:
-              type: array
-              items:
-                $ref: '#/components/schemas/test.v1.AllTypes'
-              title: msg_list
-            enumList:
-              type: array
-              items:
-                $ref: '#/components/schemas/test.v1.AllTypes.Enum'
-              title: enum_list
-            msgMap:
-              type: object
-              title: msg_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/test.v1.AllTypes'
-                title: value
-            enumMap:
-              type: object
-              title: enum_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
-                title: value
-        - oneOf:
-            - type: object
-              properties:
-                boolOption:
-                  type: boolean
-                  title: bool_option
               title: bool_option
-              required:
-                - boolOption
-            - type: object
-              properties:
-                bytesOption:
-                  type: string
-                  title: bytes_option
-                  format: byte
+          title: bool_option
+        - type: object
+          properties:
+            bytesOption:
+              type: string
               title: bytes_option
-              required:
-                - bytesOption
-            - type: object
-              properties:
-                doubleOption:
-                  type: number
-                  title: double_option
-                  format: double
-                  deprecated: true
+              format: byte
+          title: bytes_option
+        - type: object
+          properties:
+            doubleOption:
+              type: number
               title: double_option
-              required:
-                - doubleOption
-            - type: object
-              properties:
-                enumOption:
-                  allOf:
-                    - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
-                  title: enum_option
+              format: double
+              deprecated: true
+          title: double_option
+        - type: object
+          properties:
+            enumOption:
+              allOf:
+                - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
               title: enum_option
-              required:
-                - enumOption
-            - type: object
-              properties:
-                fixed32Option:
-                  type: integer
-                  title: fixed32_option
+          title: enum_option
+        - type: object
+          properties:
+            fixed32Option:
+              type: integer
               title: fixed32_option
-              required:
-                - fixed32Option
-            - type: object
-              properties:
-                fixed64Option:
-                  type: string
-                  title: fixed64_option
-                  format: int64
+          title: fixed32_option
+        - type: object
+          properties:
+            fixed64Option:
+              type: string
               title: fixed64_option
-              required:
-                - fixed64Option
-            - type: object
-              properties:
-                floatOption:
-                  type: number
-                  title: float_option
-                  format: float
+              format: int64
+          title: fixed64_option
+        - type: object
+          properties:
+            floatOption:
+              type: number
               title: float_option
-              required:
-                - floatOption
-            - type: object
-              properties:
-                int32Option:
-                  type: integer
-                  title: int32_option
-                  format: int32
+              format: float
+          title: float_option
+        - type: object
+          properties:
+            int32Option:
+              type: integer
               title: int32_option
-              required:
-                - int32Option
-            - type: object
-              properties:
-                int64Option:
-                  type: string
-                  title: int64_option
-                  format: int64
+              format: int32
+          title: int32_option
+        - type: object
+          properties:
+            int64Option:
+              type: string
               title: int64_option
-              required:
-                - int64Option
-            - type: object
-              properties:
-                msgOption:
-                  allOf:
-                    - $ref: '#/components/schemas/test.v1.AllTypes'
-                  title: msg_option
+              format: int64
+          title: int64_option
+        - type: object
+          properties:
+            msgOption:
+              allOf:
+                - $ref: '#/components/schemas/test.v1.AllTypes'
               title: msg_option
-              required:
-                - msgOption
-            - type: object
-              properties:
-                sfixed32Option:
-                  type: integer
-                  title: sfixed32_option
-                  format: int32
+          title: msg_option
+        - type: object
+          properties:
+            sfixed32Option:
+              type: integer
               title: sfixed32_option
-              required:
-                - sfixed32Option
-            - type: object
-              properties:
-                sfixed64Option:
-                  type: string
-                  title: sfixed64_option
-                  format: int64
+              format: int32
+          title: sfixed32_option
+        - type: object
+          properties:
+            sfixed64Option:
+              type: string
               title: sfixed64_option
-              required:
-                - sfixed64Option
-            - type: object
-              properties:
-                sint32Option:
-                  type: integer
-                  title: sint32_option
-                  format: int32
+              format: int64
+          title: sfixed64_option
+        - type: object
+          properties:
+            sint32Option:
+              type: integer
               title: sint32_option
-              required:
-                - sint32Option
-            - type: object
-              properties:
-                sint64Option:
-                  type: string
-                  title: sint64_option
-                  format: int64
+              format: int32
+          title: sint32_option
+        - type: object
+          properties:
+            sint64Option:
+              type: string
               title: sint64_option
-              required:
-                - sint64Option
-            - type: object
-              properties:
-                stringOption:
-                  type: string
-                  title: string_option
+              format: int64
+          title: sint64_option
+        - type: object
+          properties:
+            stringOption:
+              type: string
               title: string_option
-              required:
-                - stringOption
-            - type: object
-              properties:
-                uint32Option:
-                  type: integer
-                  title: uint32_option
+          title: string_option
+        - type: object
+          properties:
+            uint32Option:
+              type: integer
               title: uint32_option
-              required:
-                - uint32Option
-            - type: object
-              properties:
-                uint64Option:
-                  type: string
-                  title: uint64_option
-                  format: int64
+          title: uint32_option
+        - type: object
+          properties:
+            uint64Option:
+              type: string
               title: uint64_option
-              required:
-                - uint64Option
-            - not:
-                anyOf:
-                  - required:
-                      - boolOption
-                  - required:
-                      - bytesOption
-                  - required:
-                      - doubleOption
-                  - required:
-                      - enumOption
-                  - required:
-                      - fixed32Option
-                  - required:
-                      - fixed64Option
-                  - required:
-                      - floatOption
-                  - required:
-                      - int32Option
-                  - required:
-                      - int64Option
-                  - required:
-                      - msgOption
-                  - required:
-                      - sfixed32Option
-                  - required:
-                      - sfixed64Option
-                  - required:
-                      - sint32Option
-                  - required:
-                      - sint64Option
-                  - required:
-                      - stringOption
-                  - required:
-                      - uint32Option
-                  - required:
-                      - uint64Option
+              format: int64
+          title: uint64_option
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - boolOption
+              - required:
+                  - bytesOption
+              - required:
+                  - doubleOption
+              - required:
+                  - enumOption
+              - required:
+                  - fixed32Option
+              - required:
+                  - fixed64Option
+              - required:
+                  - floatOption
+              - required:
+                  - int32Option
+              - required:
+                  - int64Option
+              - required:
+                  - msgOption
+              - required:
+                  - sfixed32Option
+              - required:
+                  - sfixed64Option
+              - required:
+                  - sint32Option
+              - required:
+                  - sint64Option
+              - required:
+                  - stringOption
+              - required:
+                  - uint32Option
+              - required:
+                  - uint64Option
+          - not:
+              oneOf:
+                - required:
+                    - boolOption
+                - required:
+                    - bytesOption
+                - required:
+                    - doubleOption
+                - required:
+                    - enumOption
+                - required:
+                    - fixed32Option
+                - required:
+                    - fixed64Option
+                - required:
+                    - floatOption
+                - required:
+                    - int32Option
+                - required:
+                    - int64Option
+                - required:
+                    - msgOption
+                - required:
+                    - sfixed32Option
+                - required:
+                    - sfixed64Option
+                - required:
+                    - sint32Option
+                - required:
+                    - sint64Option
+                - required:
+                    - stringOption
+                - required:
+                    - uint32Option
+                - required:
+                    - uint64Option
+      properties:
+        doubleValue:
+          type: number
+          title: double_value
+          format: double
+          description: scalar types
+        floatValue:
+          type: number
+          title: float_value
+          format: float
+        int32Value:
+          type: integer
+          title: int32_value
+          format: int32
+        int64Value:
+          type: string
+          title: int64_value
+          format: int64
+        uint32Value:
+          type: integer
+          title: uint32_value
+        uint64Value:
+          type: string
+          title: uint64_value
+          format: int64
+        sint32Value:
+          type: integer
+          title: sint32_value
+          format: int32
+        sint64Value:
+          type: string
+          title: sint64_value
+          format: int64
+        fixed32Value:
+          type: integer
+          title: fixed32_value
+        fixed64Value:
+          type: string
+          title: fixed64_value
+          format: int64
+        sfixed32Value:
+          type: integer
+          title: sfixed32_value
+          format: int32
+        sfixed64Value:
+          type: string
+          title: sfixed64_value
+          format: int64
+        boolValue:
+          type: boolean
+          title: bool_value
+        stringValue:
+          type: string
+          title: string_value
+        bytesValue:
+          type: string
+          title: bytes_value
+          format: byte
+        doubleList:
+          type: array
+          items:
+            type: number
+            format: double
+          title: double_list
+          description: repeated types
+        floatList:
+          type: array
+          items:
+            type: number
+            format: float
+          title: float_list
+        int32List:
+          type: array
+          items:
+            type: integer
+            format: int32
+          title: int32_list
+        int64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: int64_list
+        uint32List:
+          type: array
+          items:
+            type: integer
+          title: uint32_list
+        uint64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: uint64_list
+        sint32List:
+          type: array
+          items:
+            type: integer
+            format: int32
+          title: sint32_list
+        sint64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: sint64_list
+        fixed32List:
+          type: array
+          items:
+            type: integer
+          title: fixed32_list
+        fixed64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: fixed64_list
+        sfixed32List:
+          type: array
+          items:
+            type: integer
+            format: int32
+          title: sfixed32_list
+        sfixed64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: sfixed64_list
+        boolList:
+          type: array
+          items:
+            type: boolean
+          title: bool_list
+        stringList:
+          type: array
+          items:
+            type: string
+          title: string_list
+        bytesList:
+          type: array
+          items:
+            type: string
+            format: byte
+          title: bytes_list
+        int32ToStringMap:
+          type: object
+          title: int32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+          description: map key types
+        int64ToStringMap:
+          type: object
+          title: int64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        uint32ToStringMap:
+          type: object
+          title: uint32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        uint64ToStringMap:
+          type: object
+          title: uint64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        sint32ToStringMap:
+          type: object
+          title: sint32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        sint64ToStringMap:
+          type: object
+          title: sint64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        fixed32ToStringMap:
+          type: object
+          title: fixed32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        fixed64ToStringMap:
+          type: object
+          title: fixed64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        sfixed32ToStringMap:
+          type: object
+          title: sfixed32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        sfixed64ToStringMap:
+          type: object
+          title: sfixed64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        boolToStringMap:
+          type: object
+          title: bool_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        stringToStringMap:
+          type: object
+          title: string_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+        doubleMap:
+          type: object
+          title: double_map
+          additionalProperties:
+            type: number
+            title: value
+            format: double
+          description: map value types
+          deprecated: true
+        floatMap:
+          type: object
+          title: float_map
+          additionalProperties:
+            type: number
+            title: value
+            format: float
+        int32Map:
+          type: object
+          title: int32_map
+          additionalProperties:
+            type: integer
+            title: value
+            format: int32
+        int64Map:
+          type: object
+          title: int64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+        uint32Map:
+          type: object
+          title: uint32_map
+          additionalProperties:
+            type: integer
+            title: value
+        uint64Map:
+          type: object
+          title: uint64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+        sint32Map:
+          type: object
+          title: sint32_map
+          additionalProperties:
+            type: integer
+            title: value
+            format: int32
+        sint64Map:
+          type: object
+          title: sint64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+        fixed32Map:
+          type: object
+          title: fixed32_map
+          additionalProperties:
+            type: integer
+            title: value
+        fixed64Map:
+          type: object
+          title: fixed64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+        sfixed32Map:
+          type: object
+          title: sfixed32_map
+          additionalProperties:
+            type: integer
+            title: value
+            format: int32
+        sfixed64Map:
+          type: object
+          title: sfixed64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+        boolMap:
+          type: object
+          title: bool_map
+          additionalProperties:
+            type: boolean
+            title: value
+        stringMap:
+          type: object
+          title: string_map
+          additionalProperties:
+            type: string
+            title: value
+        bytesMap:
+          type: object
+          title: bytes_map
+          additionalProperties:
+            type: string
+            title: value
+            format: byte
+        optDoubleValue:
+          type:
+            - number
+            - "null"
+          title: opt_double_value
+          format: double
+          description: explicit presence types
+          deprecated: true
+        optFloatValue:
+          type:
+            - number
+            - "null"
+          title: opt_float_value
+          format: float
+        optInt32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_int32_value
+          format: int32
+        optInt64Value:
+          type:
+            - string
+            - "null"
+          title: opt_int64_value
+          format: int64
+        optUint32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_uint32_value
+        optUint64Value:
+          type:
+            - string
+            - "null"
+          title: opt_uint64_value
+          format: int64
+        optSint32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_sint32_value
+          format: int32
+        optSint64Value:
+          type:
+            - string
+            - "null"
+          title: opt_sint64_value
+          format: int64
+        optFixed32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_fixed32_value
+        optFixed64Value:
+          type:
+            - string
+            - "null"
+          title: opt_fixed64_value
+          format: int64
+        optSfixed32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_sfixed32_value
+          format: int32
+        optSfixed64Value:
+          type:
+            - string
+            - "null"
+          title: opt_sfixed64_value
+          format: int64
+        optBoolValue:
+          type:
+            - boolean
+            - "null"
+          title: opt_bool_value
+        optStringValue:
+          type:
+            - string
+            - "null"
+          title: opt_string_value
+        optBytesValue:
+          type:
+            - string
+            - "null"
+          title: opt_bytes_value
+          format: byte
+        msgValue:
+          allOf:
+            - $ref: '#/components/schemas/test.v1.AllTypes'
+          title: msg_value
+          deprecated: true
+        enumValue:
+          allOf:
+            - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
+          title: enum_value
+        optMsgValue:
+          oneOf:
+            - $ref: '#/components/schemas/test.v1.AllTypes'
+            - type: "null"
+          title: opt_msg_value
+        optEnumValue:
+          oneOf:
+            - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
+            - type: "null"
+          title: opt_enum_value
+        msgList:
+          type: array
+          items:
+            $ref: '#/components/schemas/test.v1.AllTypes'
+          title: msg_list
+        enumList:
+          type: array
+          items:
+            $ref: '#/components/schemas/test.v1.AllTypes.Enum'
+          title: enum_list
+        msgMap:
+          type: object
+          title: msg_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/test.v1.AllTypes'
+            title: value
+        enumMap:
+          type: object
+          title: enum_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/test.v1.AllTypes.Enum'
+            title: value
       title: AllTypes
     test.v1.AllTypes.Enum:
       type: string
@@ -740,222 +742,224 @@ components:
       description: named types
     test.v1.ParameterValues:
       type: object
-      allOf:
-        - properties:
-            doubleValue:
+      anyOf:
+        - type: object
+          properties:
+            oneofDoubleValue:
               type: number
-              title: double_value
+              title: oneof_double_value
               format: double
-              description: scalar types
-            floatValue:
-              type: number
-              title: float_value
-              format: float
-            int32Value:
-              type: integer
-              title: int32_value
-              format: int32
-            int64Value:
-              type: string
-              title: int64_value
-              format: int64
-            uint32Value:
-              type: integer
-              title: uint32_value
-            uint64Value:
-              type: string
-              title: uint64_value
-              format: int64
-            sint32Value:
-              type: integer
-              title: sint32_value
-              format: int32
-            sint64Value:
-              type: string
-              title: sint64_value
-              format: int64
-            fixed32Value:
-              type: integer
-              title: fixed32_value
-            fixed64Value:
-              type: string
-              title: fixed64_value
-              format: int64
-            sfixed32Value:
-              type: integer
-              title: sfixed32_value
-              format: int32
-            sfixed64Value:
-              type: string
-              title: sfixed64_value
-              format: int64
-            boolValue:
-              type: boolean
-              title: bool_value
-            stringValue:
-              type: string
-              title: string_value
-            bytesValue:
-              type: string
-              title: bytes_value
-              format: byte
-            timestamp:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Timestamp'
-              title: timestamp
-              description: scalar wrappers
-            duration:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Duration'
-              title: duration
-            boolValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.BoolValue'
-              title: bool_value_wrapper
-            int32ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Int32Value'
-              title: int32_value_wrapper
-            int64ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Int64Value'
-              title: int64_value_wrapper
-            uint32ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.UInt32Value'
-              title: uint32_value_wrapper
-            uint64ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.UInt64Value'
-              title: uint64_value_wrapper
-            floatValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.FloatValue'
-              title: float_value_wrapper
-            doubleValueWrapper:
+          title: oneof_double_value
+        - type: object
+          properties:
+            oneofDoubleValueWrapper:
               allOf:
                 - $ref: '#/components/schemas/google.protobuf.DoubleValue'
-              title: double_value_wrapper
-            bytesValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.BytesValue'
-              title: bytes_value_wrapper
-            stringValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.StringValue'
-              title: string_value_wrapper
-            fieldMask:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.FieldMask'
-              title: field_mask
-            enumValue:
+              title: oneof_double_value_wrapper
+          title: oneof_double_value_wrapper
+        - type: object
+          properties:
+            oneofEnumValue:
               allOf:
                 - $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
-              title: enum_value
-            enumList:
-              type: array
-              items:
-                $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
-              title: enum_list
-              description: complex types
-              deprecated: true
-            doubleList:
-              type: array
-              items:
-                type: number
-                format: double
-              title: double_list
-            doubleValueList:
-              type: array
-              items:
-                $ref: '#/components/schemas/google.protobuf.DoubleValue'
-              title: double_value_list
-            nested:
-              allOf:
-                - $ref: '#/components/schemas/test.v1.ParameterValues.Nested'
-              title: nested
-            recursive:
-              allOf:
-                - $ref: '#/components/schemas/test.v1.ParameterValues'
-              title: recursive
-            stringMap:
-              type: object
-              title: string_map
-              additionalProperties:
-                type: string
-                title: value
-              description: unsupported
-            stringValueMap:
-              type: object
-              title: string_value_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/google.protobuf.StringValue'
-                title: value
-            enumMap:
-              type: object
-              title: enum_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
-                title: value
-            nestedMap:
-              type: object
-              title: nested_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/test.v1.ParameterValues.Nested'
-                title: value
-            structValue:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Struct'
-              title: struct_value
-            value:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Value'
-              title: value
-            recursiveList:
-              type: array
-              items:
-                $ref: '#/components/schemas/test.v1.ParameterValues'
-              title: recursive_list
-        - oneOf:
-            - type: object
-              properties:
-                oneofDoubleValue:
-                  type: number
-                  title: oneof_double_value
-                  format: double
-              title: oneof_double_value
-              required:
-                - oneofDoubleValue
-            - type: object
-              properties:
-                oneofDoubleValueWrapper:
-                  allOf:
-                    - $ref: '#/components/schemas/google.protobuf.DoubleValue'
-                  title: oneof_double_value_wrapper
-              title: oneof_double_value_wrapper
-              required:
-                - oneofDoubleValueWrapper
-            - type: object
-              properties:
-                oneofEnumValue:
-                  allOf:
-                    - $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
-                  title: oneof_enum_value
               title: oneof_enum_value
-              required:
-                - oneofEnumValue
-            - not:
-                anyOf:
-                  - required:
-                      - oneofDoubleValue
-                  - required:
-                      - oneofDoubleValueWrapper
-                  - required:
-                      - oneofEnumValue
+          title: oneof_enum_value
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - oneofDoubleValue
+              - required:
+                  - oneofDoubleValueWrapper
+              - required:
+                  - oneofEnumValue
+          - not:
+              oneOf:
+                - required:
+                    - oneofDoubleValue
+                - required:
+                    - oneofDoubleValueWrapper
+                - required:
+                    - oneofEnumValue
+      properties:
+        doubleValue:
+          type: number
+          title: double_value
+          format: double
+          description: scalar types
+        floatValue:
+          type: number
+          title: float_value
+          format: float
+        int32Value:
+          type: integer
+          title: int32_value
+          format: int32
+        int64Value:
+          type: string
+          title: int64_value
+          format: int64
+        uint32Value:
+          type: integer
+          title: uint32_value
+        uint64Value:
+          type: string
+          title: uint64_value
+          format: int64
+        sint32Value:
+          type: integer
+          title: sint32_value
+          format: int32
+        sint64Value:
+          type: string
+          title: sint64_value
+          format: int64
+        fixed32Value:
+          type: integer
+          title: fixed32_value
+        fixed64Value:
+          type: string
+          title: fixed64_value
+          format: int64
+        sfixed32Value:
+          type: integer
+          title: sfixed32_value
+          format: int32
+        sfixed64Value:
+          type: string
+          title: sfixed64_value
+          format: int64
+        boolValue:
+          type: boolean
+          title: bool_value
+        stringValue:
+          type: string
+          title: string_value
+        bytesValue:
+          type: string
+          title: bytes_value
+          format: byte
+        timestamp:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Timestamp'
+          title: timestamp
+          description: scalar wrappers
+        duration:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Duration'
+          title: duration
+        boolValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.BoolValue'
+          title: bool_value_wrapper
+        int32ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Int32Value'
+          title: int32_value_wrapper
+        int64ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Int64Value'
+          title: int64_value_wrapper
+        uint32ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.UInt32Value'
+          title: uint32_value_wrapper
+        uint64ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.UInt64Value'
+          title: uint64_value_wrapper
+        floatValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.FloatValue'
+          title: float_value_wrapper
+        doubleValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.DoubleValue'
+          title: double_value_wrapper
+        bytesValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.BytesValue'
+          title: bytes_value_wrapper
+        stringValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.StringValue'
+          title: string_value_wrapper
+        fieldMask:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.FieldMask'
+          title: field_mask
+        enumValue:
+          allOf:
+            - $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
+          title: enum_value
+        enumList:
+          type: array
+          items:
+            $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
+          title: enum_list
+          description: complex types
+          deprecated: true
+        doubleList:
+          type: array
+          items:
+            type: number
+            format: double
+          title: double_list
+        doubleValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/google.protobuf.DoubleValue'
+          title: double_value_list
+        nested:
+          allOf:
+            - $ref: '#/components/schemas/test.v1.ParameterValues.Nested'
+          title: nested
+        recursive:
+          allOf:
+            - $ref: '#/components/schemas/test.v1.ParameterValues'
+          title: recursive
+        stringMap:
+          type: object
+          title: string_map
+          additionalProperties:
+            type: string
+            title: value
+          description: unsupported
+        stringValueMap:
+          type: object
+          title: string_value_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/google.protobuf.StringValue'
+            title: value
+        enumMap:
+          type: object
+          title: enum_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/test.v1.ParameterValues.Enum'
+            title: value
+        nestedMap:
+          type: object
+          title: nested_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/test.v1.ParameterValues.Nested'
+            title: value
+        structValue:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Struct'
+          title: struct_value
+        value:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Value'
+          title: value
+        recursiveList:
+          type: array
+          items:
+            $ref: '#/components/schemas/test.v1.ParameterValues'
+          title: recursive_list
       title: ParameterValues
     test.v1.ParameterValues.Enum:
       type: string

--- a/internal/converter/testdata/with_proto_annotations/output/test.openapi.json
+++ b/internal/converter/testdata/with_proto_annotations/output/test.openapi.json
@@ -139,1080 +139,1116 @@
       },
       "with_proto_annotations.test.v1.AllTypes": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "doubleValue": {
-                "type": "number",
-                "title": "double_value",
-                "format": "double",
-                "description": "scalar types (proto double)"
-              },
-              "floatValue": {
-                "type": "number",
-                "title": "float_value",
-                "format": "float",
-                "description": "(proto float)"
-              },
-              "int32Value": {
-                "type": "integer",
-                "title": "int32_value",
-                "format": "int32",
-                "description": "(proto int32)"
-              },
-              "int64Value": {
-                "type": "string",
-                "title": "int64_value",
-                "format": "int64",
-                "description": "(proto int64)"
-              },
-              "uint32Value": {
-                "type": "integer",
-                "title": "uint32_value",
-                "description": "(proto uint32)"
-              },
-              "uint64Value": {
-                "type": "string",
-                "title": "uint64_value",
-                "format": "int64",
-                "description": "(proto uint64)"
-              },
-              "sint32Value": {
-                "type": "integer",
-                "title": "sint32_value",
-                "format": "int32",
-                "description": "(proto sint32)"
-              },
-              "sint64Value": {
-                "type": "string",
-                "title": "sint64_value",
-                "format": "int64",
-                "description": "(proto sint64)"
-              },
-              "fixed32Value": {
-                "type": "integer",
-                "title": "fixed32_value",
-                "description": "(proto fixed32)"
-              },
-              "fixed64Value": {
-                "type": "string",
-                "title": "fixed64_value",
-                "format": "int64",
-                "description": "(proto fixed64)"
-              },
-              "sfixed32Value": {
-                "type": "integer",
-                "title": "sfixed32_value",
-                "format": "int32",
-                "description": "(proto sfixed32)"
-              },
-              "sfixed64Value": {
-                "type": "string",
-                "title": "sfixed64_value",
-                "format": "int64",
-                "description": "(proto sfixed64)"
-              },
-              "boolValue": {
+              "boolOption": {
                 "type": "boolean",
-                "title": "bool_value",
+                "title": "bool_option",
                 "description": "(proto bool)"
-              },
-              "stringValue": {
-                "type": "string",
-                "title": "string_value",
-                "description": "(proto string)"
-              },
-              "bytesValue": {
-                "type": "string",
-                "title": "bytes_value",
-                "format": "byte",
-                "description": "(proto bytes)"
-              },
-              "doubleList": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "title": "double_list",
-                "description": "repeated types (proto double)"
-              },
-              "floatList": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "float"
-                },
-                "title": "float_list",
-                "description": "(proto float)"
-              },
-              "int32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "title": "int32_list",
-                "description": "(proto int32)"
-              },
-              "int64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "int64_list",
-                "description": "(proto int64)"
-              },
-              "uint32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                },
-                "title": "uint32_list",
-                "description": "(proto uint32)"
-              },
-              "uint64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "uint64_list",
-                "description": "(proto uint64)"
-              },
-              "sint32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "title": "sint32_list",
-                "description": "(proto sint32)"
-              },
-              "sint64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "sint64_list",
-                "description": "(proto sint64)"
-              },
-              "fixed32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                },
-                "title": "fixed32_list",
-                "description": "(proto fixed32)"
-              },
-              "fixed64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "fixed64_list",
-                "description": "(proto fixed64)"
-              },
-              "sfixed32List": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "title": "sfixed32_list",
-                "description": "(proto sfixed32)"
-              },
-              "sfixed64List": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "int64"
-                },
-                "title": "sfixed64_list",
-                "description": "(proto sfixed64)"
-              },
-              "boolList": {
-                "type": "array",
-                "items": {
-                  "type": "boolean"
-                },
-                "title": "bool_list",
-                "description": "(proto bool)"
-              },
-              "stringList": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "title": "string_list",
-                "description": "(proto string)"
-              },
-              "bytesList": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "byte"
-                },
-                "title": "bytes_list",
-                "description": "(proto bytes)"
-              },
-              "int32ToStringMap": {
-                "type": "object",
-                "title": "int32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "map key types (proto with_proto_annotations.test.v1.AllTypes.Int32ToStringMapEntry)"
-              },
-              "int64ToStringMap": {
-                "type": "object",
-                "title": "int64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Int64ToStringMapEntry)"
-              },
-              "uint32ToStringMap": {
-                "type": "object",
-                "title": "uint32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint32ToStringMapEntry)"
-              },
-              "uint64ToStringMap": {
-                "type": "object",
-                "title": "uint64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint64ToStringMapEntry)"
-              },
-              "sint32ToStringMap": {
-                "type": "object",
-                "title": "sint32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint32ToStringMapEntry)"
-              },
-              "sint64ToStringMap": {
-                "type": "object",
-                "title": "sint64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint64ToStringMapEntry)"
-              },
-              "fixed32ToStringMap": {
-                "type": "object",
-                "title": "fixed32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed32ToStringMapEntry)"
-              },
-              "fixed64ToStringMap": {
-                "type": "object",
-                "title": "fixed64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed64ToStringMapEntry)"
-              },
-              "sfixed32ToStringMap": {
-                "type": "object",
-                "title": "sfixed32_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed32ToStringMapEntry)"
-              },
-              "sfixed64ToStringMap": {
-                "type": "object",
-                "title": "sfixed64_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed64ToStringMapEntry)"
-              },
-              "boolToStringMap": {
-                "type": "object",
-                "title": "bool_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.BoolToStringMapEntry)"
-              },
-              "stringToStringMap": {
-                "type": "object",
-                "title": "string_to_string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.StringToStringMapEntry)"
-              },
-              "doubleMap": {
-                "type": "object",
-                "title": "double_map",
-                "additionalProperties": {
-                  "type": "number",
-                  "title": "value",
-                  "format": "double",
-                  "description": "(proto double)"
-                },
-                "description": "map value types (proto with_proto_annotations.test.v1.AllTypes.DoubleMapEntry)"
-              },
-              "floatMap": {
-                "type": "object",
-                "title": "float_map",
-                "additionalProperties": {
-                  "type": "number",
-                  "title": "value",
-                  "format": "float",
-                  "description": "(proto float)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.FloatMapEntry)"
-              },
-              "int32Map": {
-                "type": "object",
-                "title": "int32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "format": "int32",
-                  "description": "(proto int32)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Int32MapEntry)"
-              },
-              "int64Map": {
-                "type": "object",
-                "title": "int64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64",
-                  "description": "(proto int64)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Int64MapEntry)"
-              },
-              "uint32Map": {
-                "type": "object",
-                "title": "uint32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "description": "(proto uint32)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint32MapEntry)"
-              },
-              "uint64Map": {
-                "type": "object",
-                "title": "uint64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64",
-                  "description": "(proto uint64)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint64MapEntry)"
-              },
-              "sint32Map": {
-                "type": "object",
-                "title": "sint32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "format": "int32",
-                  "description": "(proto sint32)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint32MapEntry)"
-              },
-              "sint64Map": {
-                "type": "object",
-                "title": "sint64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64",
-                  "description": "(proto sint64)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint64MapEntry)"
-              },
-              "fixed32Map": {
-                "type": "object",
-                "title": "fixed32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "description": "(proto fixed32)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed32MapEntry)"
-              },
-              "fixed64Map": {
-                "type": "object",
-                "title": "fixed64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64",
-                  "description": "(proto fixed64)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed64MapEntry)"
-              },
-              "sfixed32Map": {
-                "type": "object",
-                "title": "sfixed32_map",
-                "additionalProperties": {
-                  "type": "integer",
-                  "title": "value",
-                  "format": "int32",
-                  "description": "(proto sfixed32)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed32MapEntry)"
-              },
-              "sfixed64Map": {
-                "type": "object",
-                "title": "sfixed64_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "int64",
-                  "description": "(proto sfixed64)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed64MapEntry)"
-              },
-              "boolMap": {
-                "type": "object",
-                "title": "bool_map",
-                "additionalProperties": {
-                  "type": "boolean",
-                  "title": "value",
-                  "description": "(proto bool)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.BoolMapEntry)"
-              },
-              "stringMap": {
-                "type": "object",
-                "title": "string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.StringMapEntry)"
-              },
-              "bytesMap": {
-                "type": "object",
-                "title": "bytes_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "format": "byte",
-                  "description": "(proto bytes)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.BytesMapEntry)"
-              },
-              "optDoubleValue": {
-                "type": [
-                  "number",
-                  "null"
-                ],
-                "title": "opt_double_value",
-                "format": "double",
-                "description": "explicit presence types (proto double)"
-              },
-              "optFloatValue": {
-                "type": [
-                  "number",
-                  "null"
-                ],
-                "title": "opt_float_value",
-                "format": "float",
-                "description": "(proto float)"
-              },
-              "optInt32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_int32_value",
-                "format": "int32",
-                "description": "(proto int32)"
-              },
-              "optInt64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_int64_value",
-                "format": "int64",
-                "description": "(proto int64)"
-              },
-              "optUint32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_uint32_value",
-                "description": "(proto uint32)"
-              },
-              "optUint64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_uint64_value",
-                "format": "int64",
-                "description": "(proto uint64)"
-              },
-              "optSint32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_sint32_value",
-                "format": "int32",
-                "description": "(proto sint32)"
-              },
-              "optSint64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_sint64_value",
-                "format": "int64",
-                "description": "(proto sint64)"
-              },
-              "optFixed32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_fixed32_value",
-                "description": "(proto fixed32)"
-              },
-              "optFixed64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_fixed64_value",
-                "format": "int64",
-                "description": "(proto fixed64)"
-              },
-              "optSfixed32Value": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "title": "opt_sfixed32_value",
-                "format": "int32",
-                "description": "(proto sfixed32)"
-              },
-              "optSfixed64Value": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_sfixed64_value",
-                "format": "int64",
-                "description": "(proto sfixed64)"
-              },
-              "optBoolValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "title": "opt_bool_value",
-                "description": "(proto bool)"
-              },
-              "optStringValue": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_string_value",
-                "description": "(proto string)"
-              },
-              "optBytesValue": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "title": "opt_bytes_value",
-                "format": "byte",
-                "description": "(proto bytes)"
-              },
-              "msgValue": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
-                  }
-                ],
-                "title": "msg_value",
-                "description": "(proto with_proto_annotations.test.v1.AllTypes)"
-              },
-              "enumValue": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
-                  }
-                ],
-                "title": "enum_value",
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
-              },
-              "optMsgValue": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "opt_msg_value",
-                "description": "(proto with_proto_annotations.test.v1.AllTypes)"
-              },
-              "optEnumValue": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "opt_enum_value",
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
-              },
-              "msgList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
-                },
-                "title": "msg_list",
-                "description": "(proto with_proto_annotations.test.v1.AllTypes)"
-              },
-              "enumList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
-                },
-                "title": "enum_list",
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
-              },
-              "msgMap": {
-                "type": "object",
-                "title": "msg_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
-                    }
-                  ],
-                  "title": "value",
-                  "description": "(proto with_proto_annotations.test.v1.AllTypes)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.MsgMapEntry)"
-              },
-              "enumMap": {
-                "type": "object",
-                "title": "enum_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
-                    }
-                  ],
-                  "title": "value",
-                  "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.AllTypes.EnumMapEntry)"
               }
-            }
+            },
+            "title": "bool_option"
           },
           {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "boolOption": {
-                    "type": "boolean",
-                    "title": "bool_option",
-                    "description": "(proto bool)"
-                  }
-                },
-                "title": "bool_option",
-                "required": [
-                  "boolOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "bytesOption": {
-                    "type": "string",
-                    "title": "bytes_option",
-                    "format": "byte",
-                    "description": "(proto bytes)"
-                  }
-                },
+            "type": "object",
+            "properties": {
+              "bytesOption": {
+                "type": "string",
                 "title": "bytes_option",
-                "required": [
-                  "bytesOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "doubleOption": {
-                    "type": "number",
-                    "title": "double_option",
-                    "format": "double",
-                    "description": "(proto double)"
-                  }
-                },
-                "title": "double_option",
-                "required": [
-                  "doubleOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "enumOption": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
-                      }
-                    ],
-                    "title": "enum_option",
-                    "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
-                  }
-                },
-                "title": "enum_option",
-                "required": [
-                  "enumOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "fixed32Option": {
-                    "type": "integer",
-                    "title": "fixed32_option",
-                    "description": "(proto fixed32)"
-                  }
-                },
-                "title": "fixed32_option",
-                "required": [
-                  "fixed32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "fixed64Option": {
-                    "type": "string",
-                    "title": "fixed64_option",
-                    "format": "int64",
-                    "description": "(proto fixed64)"
-                  }
-                },
-                "title": "fixed64_option",
-                "required": [
-                  "fixed64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "floatOption": {
-                    "type": "number",
-                    "title": "float_option",
-                    "format": "float",
-                    "description": "(proto float)"
-                  }
-                },
-                "title": "float_option",
-                "required": [
-                  "floatOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "int32Option": {
-                    "type": "integer",
-                    "title": "int32_option",
-                    "format": "int32",
-                    "description": "(proto int32)"
-                  }
-                },
-                "title": "int32_option",
-                "required": [
-                  "int32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "int64Option": {
-                    "type": "string",
-                    "title": "int64_option",
-                    "format": "int64",
-                    "description": "(proto int64)"
-                  }
-                },
-                "title": "int64_option",
-                "required": [
-                  "int64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "msgOption": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
-                      }
-                    ],
-                    "title": "msg_option",
-                    "description": "(proto with_proto_annotations.test.v1.AllTypes)"
-                  }
-                },
-                "title": "msg_option",
-                "required": [
-                  "msgOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sfixed32Option": {
-                    "type": "integer",
-                    "title": "sfixed32_option",
-                    "format": "int32",
-                    "description": "(proto sfixed32)"
-                  }
-                },
-                "title": "sfixed32_option",
-                "required": [
-                  "sfixed32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sfixed64Option": {
-                    "type": "string",
-                    "title": "sfixed64_option",
-                    "format": "int64",
-                    "description": "(proto sfixed64)"
-                  }
-                },
-                "title": "sfixed64_option",
-                "required": [
-                  "sfixed64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sint32Option": {
-                    "type": "integer",
-                    "title": "sint32_option",
-                    "format": "int32",
-                    "description": "(proto sint32)"
-                  }
-                },
-                "title": "sint32_option",
-                "required": [
-                  "sint32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "sint64Option": {
-                    "type": "string",
-                    "title": "sint64_option",
-                    "format": "int64",
-                    "description": "(proto sint64)"
-                  }
-                },
-                "title": "sint64_option",
-                "required": [
-                  "sint64Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "stringOption": {
-                    "type": "string",
-                    "title": "string_option",
-                    "description": "(proto string)"
-                  }
-                },
-                "title": "string_option",
-                "required": [
-                  "stringOption"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "uint32Option": {
-                    "type": "integer",
-                    "title": "uint32_option",
-                    "description": "(proto uint32)"
-                  }
-                },
-                "title": "uint32_option",
-                "required": [
-                  "uint32Option"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "uint64Option": {
-                    "type": "string",
-                    "title": "uint64_option",
-                    "format": "int64",
-                    "description": "(proto uint64)"
-                  }
-                },
-                "title": "uint64_option",
-                "required": [
-                  "uint64Option"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "boolOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bytesOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "doubleOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "enumOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "fixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "floatOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "int64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "msgOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sfixed64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "sint64Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "stringOption"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint32Option"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "uint64Option"
-                      ]
-                    }
-                  ]
-                }
+                "format": "byte",
+                "description": "(proto bytes)"
               }
-            ]
+            },
+            "title": "bytes_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "doubleOption": {
+                "type": "number",
+                "title": "double_option",
+                "format": "double",
+                "description": "(proto double)"
+              }
+            },
+            "title": "double_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "enumOption": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
+                  }
+                ],
+                "title": "enum_option",
+                "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
+              }
+            },
+            "title": "enum_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "fixed32Option": {
+                "type": "integer",
+                "title": "fixed32_option",
+                "description": "(proto fixed32)"
+              }
+            },
+            "title": "fixed32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "fixed64Option": {
+                "type": "string",
+                "title": "fixed64_option",
+                "format": "int64",
+                "description": "(proto fixed64)"
+              }
+            },
+            "title": "fixed64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "floatOption": {
+                "type": "number",
+                "title": "float_option",
+                "format": "float",
+                "description": "(proto float)"
+              }
+            },
+            "title": "float_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "int32Option": {
+                "type": "integer",
+                "title": "int32_option",
+                "format": "int32",
+                "description": "(proto int32)"
+              }
+            },
+            "title": "int32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "int64Option": {
+                "type": "string",
+                "title": "int64_option",
+                "format": "int64",
+                "description": "(proto int64)"
+              }
+            },
+            "title": "int64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "msgOption": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
+                  }
+                ],
+                "title": "msg_option",
+                "description": "(proto with_proto_annotations.test.v1.AllTypes)"
+              }
+            },
+            "title": "msg_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sfixed32Option": {
+                "type": "integer",
+                "title": "sfixed32_option",
+                "format": "int32",
+                "description": "(proto sfixed32)"
+              }
+            },
+            "title": "sfixed32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sfixed64Option": {
+                "type": "string",
+                "title": "sfixed64_option",
+                "format": "int64",
+                "description": "(proto sfixed64)"
+              }
+            },
+            "title": "sfixed64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sint32Option": {
+                "type": "integer",
+                "title": "sint32_option",
+                "format": "int32",
+                "description": "(proto sint32)"
+              }
+            },
+            "title": "sint32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "sint64Option": {
+                "type": "string",
+                "title": "sint64_option",
+                "format": "int64",
+                "description": "(proto sint64)"
+              }
+            },
+            "title": "sint64_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "stringOption": {
+                "type": "string",
+                "title": "string_option",
+                "description": "(proto string)"
+              }
+            },
+            "title": "string_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "uint32Option": {
+                "type": "integer",
+                "title": "uint32_option",
+                "description": "(proto uint32)"
+              }
+            },
+            "title": "uint32_option"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "uint64Option": {
+                "type": "string",
+                "title": "uint64_option",
+                "format": "int64",
+                "description": "(proto uint64)"
+              }
+            },
+            "title": "uint64_option"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "boolOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "bytesOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "doubleOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "enumOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "fixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "floatOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "int32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "int64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "msgOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sfixed64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "sint64Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "stringOption"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint32Option"
+                  ]
+                },
+                {
+                  "required": [
+                    "uint64Option"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "boolOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "bytesOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "doubleOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "enumOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fixed32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "fixed64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "floatOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "int32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "int64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "msgOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sfixed32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sfixed64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sint32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sint64Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "stringOption"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "uint32Option"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "uint64Option"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "doubleValue": {
+            "type": "number",
+            "title": "double_value",
+            "format": "double",
+            "description": "scalar types (proto double)"
+          },
+          "floatValue": {
+            "type": "number",
+            "title": "float_value",
+            "format": "float",
+            "description": "(proto float)"
+          },
+          "int32Value": {
+            "type": "integer",
+            "title": "int32_value",
+            "format": "int32",
+            "description": "(proto int32)"
+          },
+          "int64Value": {
+            "type": "string",
+            "title": "int64_value",
+            "format": "int64",
+            "description": "(proto int64)"
+          },
+          "uint32Value": {
+            "type": "integer",
+            "title": "uint32_value",
+            "description": "(proto uint32)"
+          },
+          "uint64Value": {
+            "type": "string",
+            "title": "uint64_value",
+            "format": "int64",
+            "description": "(proto uint64)"
+          },
+          "sint32Value": {
+            "type": "integer",
+            "title": "sint32_value",
+            "format": "int32",
+            "description": "(proto sint32)"
+          },
+          "sint64Value": {
+            "type": "string",
+            "title": "sint64_value",
+            "format": "int64",
+            "description": "(proto sint64)"
+          },
+          "fixed32Value": {
+            "type": "integer",
+            "title": "fixed32_value",
+            "description": "(proto fixed32)"
+          },
+          "fixed64Value": {
+            "type": "string",
+            "title": "fixed64_value",
+            "format": "int64",
+            "description": "(proto fixed64)"
+          },
+          "sfixed32Value": {
+            "type": "integer",
+            "title": "sfixed32_value",
+            "format": "int32",
+            "description": "(proto sfixed32)"
+          },
+          "sfixed64Value": {
+            "type": "string",
+            "title": "sfixed64_value",
+            "format": "int64",
+            "description": "(proto sfixed64)"
+          },
+          "boolValue": {
+            "type": "boolean",
+            "title": "bool_value",
+            "description": "(proto bool)"
+          },
+          "stringValue": {
+            "type": "string",
+            "title": "string_value",
+            "description": "(proto string)"
+          },
+          "bytesValue": {
+            "type": "string",
+            "title": "bytes_value",
+            "format": "byte",
+            "description": "(proto bytes)"
+          },
+          "doubleList": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            },
+            "title": "double_list",
+            "description": "repeated types (proto double)"
+          },
+          "floatList": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            },
+            "title": "float_list",
+            "description": "(proto float)"
+          },
+          "int32List": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "title": "int32_list",
+            "description": "(proto int32)"
+          },
+          "int64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "int64_list",
+            "description": "(proto int64)"
+          },
+          "uint32List": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "title": "uint32_list",
+            "description": "(proto uint32)"
+          },
+          "uint64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "uint64_list",
+            "description": "(proto uint64)"
+          },
+          "sint32List": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "title": "sint32_list",
+            "description": "(proto sint32)"
+          },
+          "sint64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "sint64_list",
+            "description": "(proto sint64)"
+          },
+          "fixed32List": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "title": "fixed32_list",
+            "description": "(proto fixed32)"
+          },
+          "fixed64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "fixed64_list",
+            "description": "(proto fixed64)"
+          },
+          "sfixed32List": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "title": "sfixed32_list",
+            "description": "(proto sfixed32)"
+          },
+          "sfixed64List": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "int64"
+            },
+            "title": "sfixed64_list",
+            "description": "(proto sfixed64)"
+          },
+          "boolList": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            },
+            "title": "bool_list",
+            "description": "(proto bool)"
+          },
+          "stringList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "string_list",
+            "description": "(proto string)"
+          },
+          "bytesList": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "byte"
+            },
+            "title": "bytes_list",
+            "description": "(proto bytes)"
+          },
+          "int32ToStringMap": {
+            "type": "object",
+            "title": "int32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "map key types (proto with_proto_annotations.test.v1.AllTypes.Int32ToStringMapEntry)"
+          },
+          "int64ToStringMap": {
+            "type": "object",
+            "title": "int64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Int64ToStringMapEntry)"
+          },
+          "uint32ToStringMap": {
+            "type": "object",
+            "title": "uint32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint32ToStringMapEntry)"
+          },
+          "uint64ToStringMap": {
+            "type": "object",
+            "title": "uint64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint64ToStringMapEntry)"
+          },
+          "sint32ToStringMap": {
+            "type": "object",
+            "title": "sint32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint32ToStringMapEntry)"
+          },
+          "sint64ToStringMap": {
+            "type": "object",
+            "title": "sint64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint64ToStringMapEntry)"
+          },
+          "fixed32ToStringMap": {
+            "type": "object",
+            "title": "fixed32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed32ToStringMapEntry)"
+          },
+          "fixed64ToStringMap": {
+            "type": "object",
+            "title": "fixed64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed64ToStringMapEntry)"
+          },
+          "sfixed32ToStringMap": {
+            "type": "object",
+            "title": "sfixed32_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed32ToStringMapEntry)"
+          },
+          "sfixed64ToStringMap": {
+            "type": "object",
+            "title": "sfixed64_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed64ToStringMapEntry)"
+          },
+          "boolToStringMap": {
+            "type": "object",
+            "title": "bool_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.BoolToStringMapEntry)"
+          },
+          "stringToStringMap": {
+            "type": "object",
+            "title": "string_to_string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.StringToStringMapEntry)"
+          },
+          "doubleMap": {
+            "type": "object",
+            "title": "double_map",
+            "additionalProperties": {
+              "type": "number",
+              "title": "value",
+              "format": "double",
+              "description": "(proto double)"
+            },
+            "description": "map value types (proto with_proto_annotations.test.v1.AllTypes.DoubleMapEntry)"
+          },
+          "floatMap": {
+            "type": "object",
+            "title": "float_map",
+            "additionalProperties": {
+              "type": "number",
+              "title": "value",
+              "format": "float",
+              "description": "(proto float)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.FloatMapEntry)"
+          },
+          "int32Map": {
+            "type": "object",
+            "title": "int32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "format": "int32",
+              "description": "(proto int32)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Int32MapEntry)"
+          },
+          "int64Map": {
+            "type": "object",
+            "title": "int64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64",
+              "description": "(proto int64)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Int64MapEntry)"
+          },
+          "uint32Map": {
+            "type": "object",
+            "title": "uint32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "description": "(proto uint32)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint32MapEntry)"
+          },
+          "uint64Map": {
+            "type": "object",
+            "title": "uint64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64",
+              "description": "(proto uint64)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Uint64MapEntry)"
+          },
+          "sint32Map": {
+            "type": "object",
+            "title": "sint32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "format": "int32",
+              "description": "(proto sint32)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint32MapEntry)"
+          },
+          "sint64Map": {
+            "type": "object",
+            "title": "sint64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64",
+              "description": "(proto sint64)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sint64MapEntry)"
+          },
+          "fixed32Map": {
+            "type": "object",
+            "title": "fixed32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "description": "(proto fixed32)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed32MapEntry)"
+          },
+          "fixed64Map": {
+            "type": "object",
+            "title": "fixed64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64",
+              "description": "(proto fixed64)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Fixed64MapEntry)"
+          },
+          "sfixed32Map": {
+            "type": "object",
+            "title": "sfixed32_map",
+            "additionalProperties": {
+              "type": "integer",
+              "title": "value",
+              "format": "int32",
+              "description": "(proto sfixed32)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed32MapEntry)"
+          },
+          "sfixed64Map": {
+            "type": "object",
+            "title": "sfixed64_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "int64",
+              "description": "(proto sfixed64)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Sfixed64MapEntry)"
+          },
+          "boolMap": {
+            "type": "object",
+            "title": "bool_map",
+            "additionalProperties": {
+              "type": "boolean",
+              "title": "value",
+              "description": "(proto bool)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.BoolMapEntry)"
+          },
+          "stringMap": {
+            "type": "object",
+            "title": "string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.StringMapEntry)"
+          },
+          "bytesMap": {
+            "type": "object",
+            "title": "bytes_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "format": "byte",
+              "description": "(proto bytes)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.BytesMapEntry)"
+          },
+          "optDoubleValue": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "title": "opt_double_value",
+            "format": "double",
+            "description": "explicit presence types (proto double)"
+          },
+          "optFloatValue": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "title": "opt_float_value",
+            "format": "float",
+            "description": "(proto float)"
+          },
+          "optInt32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_int32_value",
+            "format": "int32",
+            "description": "(proto int32)"
+          },
+          "optInt64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_int64_value",
+            "format": "int64",
+            "description": "(proto int64)"
+          },
+          "optUint32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_uint32_value",
+            "description": "(proto uint32)"
+          },
+          "optUint64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_uint64_value",
+            "format": "int64",
+            "description": "(proto uint64)"
+          },
+          "optSint32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_sint32_value",
+            "format": "int32",
+            "description": "(proto sint32)"
+          },
+          "optSint64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_sint64_value",
+            "format": "int64",
+            "description": "(proto sint64)"
+          },
+          "optFixed32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_fixed32_value",
+            "description": "(proto fixed32)"
+          },
+          "optFixed64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_fixed64_value",
+            "format": "int64",
+            "description": "(proto fixed64)"
+          },
+          "optSfixed32Value": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "title": "opt_sfixed32_value",
+            "format": "int32",
+            "description": "(proto sfixed32)"
+          },
+          "optSfixed64Value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_sfixed64_value",
+            "format": "int64",
+            "description": "(proto sfixed64)"
+          },
+          "optBoolValue": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "title": "opt_bool_value",
+            "description": "(proto bool)"
+          },
+          "optStringValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_string_value",
+            "description": "(proto string)"
+          },
+          "optBytesValue": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "title": "opt_bytes_value",
+            "format": "byte",
+            "description": "(proto bytes)"
+          },
+          "msgValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
+              }
+            ],
+            "title": "msg_value",
+            "description": "(proto with_proto_annotations.test.v1.AllTypes)"
+          },
+          "enumValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
+              }
+            ],
+            "title": "enum_value",
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
+          },
+          "optMsgValue": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "opt_msg_value",
+            "description": "(proto with_proto_annotations.test.v1.AllTypes)"
+          },
+          "optEnumValue": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "opt_enum_value",
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
+          },
+          "msgList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
+            },
+            "title": "msg_list",
+            "description": "(proto with_proto_annotations.test.v1.AllTypes)"
+          },
+          "enumList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
+            },
+            "title": "enum_list",
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
+          },
+          "msgMap": {
+            "type": "object",
+            "title": "msg_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes"
+                }
+              ],
+              "title": "value",
+              "description": "(proto with_proto_annotations.test.v1.AllTypes)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.MsgMapEntry)"
+          },
+          "enumMap": {
+            "type": "object",
+            "title": "enum_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum"
+                }
+              ],
+              "title": "value",
+              "description": "(proto with_proto_annotations.test.v1.AllTypes.Enum)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.AllTypes.EnumMapEntry)"
+          }
+        },
         "title": "AllTypes"
       },
       "with_proto_annotations.test.v1.AllTypes.Enum": {
@@ -1227,413 +1263,421 @@
       },
       "with_proto_annotations.test.v1.ParameterValues": {
         "type": "object",
-        "allOf": [
+        "anyOf": [
           {
+            "type": "object",
             "properties": {
-              "doubleValue": {
+              "oneofDoubleValue": {
                 "type": "number",
-                "title": "double_value",
+                "title": "oneof_double_value",
                 "format": "double",
-                "description": "scalar types (proto double)"
-              },
-              "floatValue": {
-                "type": "number",
-                "title": "float_value",
-                "format": "float",
-                "description": "(proto float)"
-              },
-              "int32Value": {
-                "type": "integer",
-                "title": "int32_value",
-                "format": "int32",
-                "description": "(proto int32)"
-              },
-              "int64Value": {
-                "type": "string",
-                "title": "int64_value",
-                "format": "int64",
-                "description": "(proto int64)"
-              },
-              "uint32Value": {
-                "type": "integer",
-                "title": "uint32_value",
-                "description": "(proto uint32)"
-              },
-              "uint64Value": {
-                "type": "string",
-                "title": "uint64_value",
-                "format": "int64",
-                "description": "(proto uint64)"
-              },
-              "sint32Value": {
-                "type": "integer",
-                "title": "sint32_value",
-                "format": "int32",
-                "description": "(proto sint32)"
-              },
-              "sint64Value": {
-                "type": "string",
-                "title": "sint64_value",
-                "format": "int64",
-                "description": "(proto sint64)"
-              },
-              "fixed32Value": {
-                "type": "integer",
-                "title": "fixed32_value",
-                "description": "(proto fixed32)"
-              },
-              "fixed64Value": {
-                "type": "string",
-                "title": "fixed64_value",
-                "format": "int64",
-                "description": "(proto fixed64)"
-              },
-              "sfixed32Value": {
-                "type": "integer",
-                "title": "sfixed32_value",
-                "format": "int32",
-                "description": "(proto sfixed32)"
-              },
-              "sfixed64Value": {
-                "type": "string",
-                "title": "sfixed64_value",
-                "format": "int64",
-                "description": "(proto sfixed64)"
-              },
-              "boolValue": {
-                "type": "boolean",
-                "title": "bool_value",
-                "description": "(proto bool)"
-              },
-              "stringValue": {
-                "type": "string",
-                "title": "string_value",
-                "description": "(proto string)"
-              },
-              "bytesValue": {
-                "type": "string",
-                "title": "bytes_value",
-                "format": "byte",
-                "description": "(proto bytes)"
-              },
-              "timestamp": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Timestamp"
-                  }
-                ],
-                "title": "timestamp",
-                "description": "scalar wrappers (proto google.protobuf.Timestamp)"
-              },
-              "duration": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Duration"
-                  }
-                ],
-                "title": "duration",
-                "description": "(proto google.protobuf.Duration)"
-              },
-              "boolValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.BoolValue"
-                  }
-                ],
-                "title": "bool_value_wrapper",
-                "description": "(proto google.protobuf.BoolValue)"
-              },
-              "int32ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Int32Value"
-                  }
-                ],
-                "title": "int32_value_wrapper",
-                "description": "(proto google.protobuf.Int32Value)"
-              },
-              "int64ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Int64Value"
-                  }
-                ],
-                "title": "int64_value_wrapper",
-                "description": "(proto google.protobuf.Int64Value)"
-              },
-              "uint32ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.UInt32Value"
-                  }
-                ],
-                "title": "uint32_value_wrapper",
-                "description": "(proto google.protobuf.UInt32Value)"
-              },
-              "uint64ValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.UInt64Value"
-                  }
-                ],
-                "title": "uint64_value_wrapper",
-                "description": "(proto google.protobuf.UInt64Value)"
-              },
-              "floatValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.FloatValue"
-                  }
-                ],
-                "title": "float_value_wrapper",
-                "description": "(proto google.protobuf.FloatValue)"
-              },
-              "doubleValueWrapper": {
+                "description": "(proto double)"
+              }
+            },
+            "title": "oneof_double_value"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "oneofDoubleValueWrapper": {
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/google.protobuf.DoubleValue"
                   }
                 ],
-                "title": "double_value_wrapper",
+                "title": "oneof_double_value_wrapper",
                 "description": "(proto google.protobuf.DoubleValue)"
-              },
-              "bytesValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.BytesValue"
-                  }
-                ],
-                "title": "bytes_value_wrapper",
-                "description": "(proto google.protobuf.BytesValue)"
-              },
-              "stringValueWrapper": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.StringValue"
-                  }
-                ],
-                "title": "string_value_wrapper",
-                "description": "(proto google.protobuf.StringValue)"
-              },
-              "fieldMask": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.FieldMask"
-                  }
-                ],
-                "title": "field_mask",
-                "description": "(proto google.protobuf.FieldMask)"
-              },
-              "enumValue": {
+              }
+            },
+            "title": "oneof_double_value_wrapper"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "oneofEnumValue": {
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
                   }
                 ],
-                "title": "enum_value",
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)"
-              },
-              "enumList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
-                },
-                "title": "enum_list",
-                "description": "complex types (proto with_proto_annotations.test.v1.ParameterValues.Enum)"
-              },
-              "doubleList": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "title": "double_list",
-                "description": "(proto double)"
-              },
-              "doubleValueList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/google.protobuf.DoubleValue"
-                },
-                "title": "double_value_list",
-                "description": "(proto google.protobuf.DoubleValue)"
-              },
-              "nested": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested"
-                  }
-                ],
-                "title": "nested",
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues.Nested)"
-              },
-              "recursive": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues"
-                  }
-                ],
-                "title": "recursive",
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues)"
-              },
-              "stringMap": {
-                "type": "object",
-                "title": "string_map",
-                "additionalProperties": {
-                  "type": "string",
-                  "title": "value",
-                  "description": "(proto string)"
-                },
-                "description": "unsupported (proto with_proto_annotations.test.v1.ParameterValues.StringMapEntry)"
-              },
-              "stringValueMap": {
-                "type": "object",
-                "title": "string_value_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/google.protobuf.StringValue"
-                    }
-                  ],
-                  "title": "value",
-                  "description": "(proto google.protobuf.StringValue)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues.StringValueMapEntry)"
-              },
-              "enumMap": {
-                "type": "object",
-                "title": "enum_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
-                    }
-                  ],
-                  "title": "value",
-                  "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues.EnumMapEntry)"
-              },
-              "nestedMap": {
-                "type": "object",
-                "title": "nested_map",
-                "additionalProperties": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested"
-                    }
-                  ],
-                  "title": "value",
-                  "description": "(proto with_proto_annotations.test.v1.ParameterValues.Nested)"
-                },
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues.NestedMapEntry)"
-              },
-              "structValue": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Struct"
-                  }
-                ],
-                "title": "struct_value",
-                "description": "(proto google.protobuf.Struct)"
-              },
-              "value": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/google.protobuf.Value"
-                  }
-                ],
-                "title": "value",
-                "description": "(proto google.protobuf.Value)"
-              },
-              "recursiveList": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues"
-                },
-                "title": "recursive_list",
-                "description": "(proto with_proto_annotations.test.v1.ParameterValues)"
-              }
-            }
-          },
-          {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "oneofDoubleValue": {
-                    "type": "number",
-                    "title": "oneof_double_value",
-                    "format": "double",
-                    "description": "(proto double)"
-                  }
-                },
-                "title": "oneof_double_value",
-                "required": [
-                  "oneofDoubleValue"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "oneofDoubleValueWrapper": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/google.protobuf.DoubleValue"
-                      }
-                    ],
-                    "title": "oneof_double_value_wrapper",
-                    "description": "(proto google.protobuf.DoubleValue)"
-                  }
-                },
-                "title": "oneof_double_value_wrapper",
-                "required": [
-                  "oneofDoubleValueWrapper"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "oneofEnumValue": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
-                      }
-                    ],
-                    "title": "oneof_enum_value",
-                    "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)"
-                  }
-                },
                 "title": "oneof_enum_value",
-                "required": [
-                  "oneofEnumValue"
-                ]
-              },
-              {
-                "not": {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "oneofDoubleValue"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "oneofDoubleValueWrapper"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "oneofEnumValue"
-                      ]
-                    }
-                  ]
-                }
+                "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)"
               }
-            ]
+            },
+            "title": "oneof_enum_value"
           }
         ],
         "unevaluatedProperties": false,
+        "not": {
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "required": [
+                    "oneofDoubleValue"
+                  ]
+                },
+                {
+                  "required": [
+                    "oneofDoubleValueWrapper"
+                  ]
+                },
+                {
+                  "required": [
+                    "oneofEnumValue"
+                  ]
+                }
+              ]
+            },
+            {
+              "not": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "oneofDoubleValue"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "oneofDoubleValueWrapper"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "oneofEnumValue"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "properties": {
+          "doubleValue": {
+            "type": "number",
+            "title": "double_value",
+            "format": "double",
+            "description": "scalar types (proto double)"
+          },
+          "floatValue": {
+            "type": "number",
+            "title": "float_value",
+            "format": "float",
+            "description": "(proto float)"
+          },
+          "int32Value": {
+            "type": "integer",
+            "title": "int32_value",
+            "format": "int32",
+            "description": "(proto int32)"
+          },
+          "int64Value": {
+            "type": "string",
+            "title": "int64_value",
+            "format": "int64",
+            "description": "(proto int64)"
+          },
+          "uint32Value": {
+            "type": "integer",
+            "title": "uint32_value",
+            "description": "(proto uint32)"
+          },
+          "uint64Value": {
+            "type": "string",
+            "title": "uint64_value",
+            "format": "int64",
+            "description": "(proto uint64)"
+          },
+          "sint32Value": {
+            "type": "integer",
+            "title": "sint32_value",
+            "format": "int32",
+            "description": "(proto sint32)"
+          },
+          "sint64Value": {
+            "type": "string",
+            "title": "sint64_value",
+            "format": "int64",
+            "description": "(proto sint64)"
+          },
+          "fixed32Value": {
+            "type": "integer",
+            "title": "fixed32_value",
+            "description": "(proto fixed32)"
+          },
+          "fixed64Value": {
+            "type": "string",
+            "title": "fixed64_value",
+            "format": "int64",
+            "description": "(proto fixed64)"
+          },
+          "sfixed32Value": {
+            "type": "integer",
+            "title": "sfixed32_value",
+            "format": "int32",
+            "description": "(proto sfixed32)"
+          },
+          "sfixed64Value": {
+            "type": "string",
+            "title": "sfixed64_value",
+            "format": "int64",
+            "description": "(proto sfixed64)"
+          },
+          "boolValue": {
+            "type": "boolean",
+            "title": "bool_value",
+            "description": "(proto bool)"
+          },
+          "stringValue": {
+            "type": "string",
+            "title": "string_value",
+            "description": "(proto string)"
+          },
+          "bytesValue": {
+            "type": "string",
+            "title": "bytes_value",
+            "format": "byte",
+            "description": "(proto bytes)"
+          },
+          "timestamp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Timestamp"
+              }
+            ],
+            "title": "timestamp",
+            "description": "scalar wrappers (proto google.protobuf.Timestamp)"
+          },
+          "duration": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Duration"
+              }
+            ],
+            "title": "duration",
+            "description": "(proto google.protobuf.Duration)"
+          },
+          "boolValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.BoolValue"
+              }
+            ],
+            "title": "bool_value_wrapper",
+            "description": "(proto google.protobuf.BoolValue)"
+          },
+          "int32ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Int32Value"
+              }
+            ],
+            "title": "int32_value_wrapper",
+            "description": "(proto google.protobuf.Int32Value)"
+          },
+          "int64ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Int64Value"
+              }
+            ],
+            "title": "int64_value_wrapper",
+            "description": "(proto google.protobuf.Int64Value)"
+          },
+          "uint32ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.UInt32Value"
+              }
+            ],
+            "title": "uint32_value_wrapper",
+            "description": "(proto google.protobuf.UInt32Value)"
+          },
+          "uint64ValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.UInt64Value"
+              }
+            ],
+            "title": "uint64_value_wrapper",
+            "description": "(proto google.protobuf.UInt64Value)"
+          },
+          "floatValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.FloatValue"
+              }
+            ],
+            "title": "float_value_wrapper",
+            "description": "(proto google.protobuf.FloatValue)"
+          },
+          "doubleValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.DoubleValue"
+              }
+            ],
+            "title": "double_value_wrapper",
+            "description": "(proto google.protobuf.DoubleValue)"
+          },
+          "bytesValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.BytesValue"
+              }
+            ],
+            "title": "bytes_value_wrapper",
+            "description": "(proto google.protobuf.BytesValue)"
+          },
+          "stringValueWrapper": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.StringValue"
+              }
+            ],
+            "title": "string_value_wrapper",
+            "description": "(proto google.protobuf.StringValue)"
+          },
+          "fieldMask": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.FieldMask"
+              }
+            ],
+            "title": "field_mask",
+            "description": "(proto google.protobuf.FieldMask)"
+          },
+          "enumValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
+              }
+            ],
+            "title": "enum_value",
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)"
+          },
+          "enumList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
+            },
+            "title": "enum_list",
+            "description": "complex types (proto with_proto_annotations.test.v1.ParameterValues.Enum)"
+          },
+          "doubleList": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            },
+            "title": "double_list",
+            "description": "(proto double)"
+          },
+          "doubleValueList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/google.protobuf.DoubleValue"
+            },
+            "title": "double_value_list",
+            "description": "(proto google.protobuf.DoubleValue)"
+          },
+          "nested": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested"
+              }
+            ],
+            "title": "nested",
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues.Nested)"
+          },
+          "recursive": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues"
+              }
+            ],
+            "title": "recursive",
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues)"
+          },
+          "stringMap": {
+            "type": "object",
+            "title": "string_map",
+            "additionalProperties": {
+              "type": "string",
+              "title": "value",
+              "description": "(proto string)"
+            },
+            "description": "unsupported (proto with_proto_annotations.test.v1.ParameterValues.StringMapEntry)"
+          },
+          "stringValueMap": {
+            "type": "object",
+            "title": "string_value_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/google.protobuf.StringValue"
+                }
+              ],
+              "title": "value",
+              "description": "(proto google.protobuf.StringValue)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues.StringValueMapEntry)"
+          },
+          "enumMap": {
+            "type": "object",
+            "title": "enum_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum"
+                }
+              ],
+              "title": "value",
+              "description": "(proto with_proto_annotations.test.v1.ParameterValues.Enum)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues.EnumMapEntry)"
+          },
+          "nestedMap": {
+            "type": "object",
+            "title": "nested_map",
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested"
+                }
+              ],
+              "title": "value",
+              "description": "(proto with_proto_annotations.test.v1.ParameterValues.Nested)"
+            },
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues.NestedMapEntry)"
+          },
+          "structValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Struct"
+              }
+            ],
+            "title": "struct_value",
+            "description": "(proto google.protobuf.Struct)"
+          },
+          "value": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/google.protobuf.Value"
+              }
+            ],
+            "title": "value",
+            "description": "(proto google.protobuf.Value)"
+          },
+          "recursiveList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/with_proto_annotations.test.v1.ParameterValues"
+            },
+            "title": "recursive_list",
+            "description": "(proto with_proto_annotations.test.v1.ParameterValues)"
+          }
+        },
         "title": "ParameterValues"
       },
       "with_proto_annotations.test.v1.ParameterValues.Enum": {

--- a/internal/converter/testdata/with_proto_annotations/output/test.openapi.yaml
+++ b/internal/converter/testdata/with_proto_annotations/output/test.openapi.yaml
@@ -88,764 +88,766 @@ components:
       description: 'Any JSON value: `null`, number, string, boolean, array, or object.'
     with_proto_annotations.test.v1.AllTypes:
       type: object
-      allOf:
-        - properties:
-            doubleValue:
-              type: number
-              title: double_value
-              format: double
-              description: scalar types (proto double)
-            floatValue:
-              type: number
-              title: float_value
-              format: float
-              description: (proto float)
-            int32Value:
-              type: integer
-              title: int32_value
-              format: int32
-              description: (proto int32)
-            int64Value:
-              type: string
-              title: int64_value
-              format: int64
-              description: (proto int64)
-            uint32Value:
-              type: integer
-              title: uint32_value
-              description: (proto uint32)
-            uint64Value:
-              type: string
-              title: uint64_value
-              format: int64
-              description: (proto uint64)
-            sint32Value:
-              type: integer
-              title: sint32_value
-              format: int32
-              description: (proto sint32)
-            sint64Value:
-              type: string
-              title: sint64_value
-              format: int64
-              description: (proto sint64)
-            fixed32Value:
-              type: integer
-              title: fixed32_value
-              description: (proto fixed32)
-            fixed64Value:
-              type: string
-              title: fixed64_value
-              format: int64
-              description: (proto fixed64)
-            sfixed32Value:
-              type: integer
-              title: sfixed32_value
-              format: int32
-              description: (proto sfixed32)
-            sfixed64Value:
-              type: string
-              title: sfixed64_value
-              format: int64
-              description: (proto sfixed64)
-            boolValue:
+      anyOf:
+        - type: object
+          properties:
+            boolOption:
               type: boolean
-              title: bool_value
+              title: bool_option
               description: (proto bool)
-            stringValue:
+          title: bool_option
+        - type: object
+          properties:
+            bytesOption:
               type: string
-              title: string_value
-              description: (proto string)
-            bytesValue:
-              type: string
-              title: bytes_value
+              title: bytes_option
               format: byte
               description: (proto bytes)
-            doubleList:
-              type: array
-              items:
-                type: number
-                format: double
-              title: double_list
-              description: repeated types (proto double)
-            floatList:
-              type: array
-              items:
-                type: number
-                format: float
-              title: float_list
-              description: (proto float)
-            int32List:
-              type: array
-              items:
-                type: integer
-                format: int32
-              title: int32_list
-              description: (proto int32)
-            int64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: int64_list
-              description: (proto int64)
-            uint32List:
-              type: array
-              items:
-                type: integer
-              title: uint32_list
-              description: (proto uint32)
-            uint64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: uint64_list
-              description: (proto uint64)
-            sint32List:
-              type: array
-              items:
-                type: integer
-                format: int32
-              title: sint32_list
-              description: (proto sint32)
-            sint64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: sint64_list
-              description: (proto sint64)
-            fixed32List:
-              type: array
-              items:
-                type: integer
-              title: fixed32_list
-              description: (proto fixed32)
-            fixed64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: fixed64_list
-              description: (proto fixed64)
-            sfixed32List:
-              type: array
-              items:
-                type: integer
-                format: int32
-              title: sfixed32_list
-              description: (proto sfixed32)
-            sfixed64List:
-              type: array
-              items:
-                type: string
-                format: int64
-              title: sfixed64_list
-              description: (proto sfixed64)
-            boolList:
-              type: array
-              items:
-                type: boolean
-              title: bool_list
-              description: (proto bool)
-            stringList:
-              type: array
-              items:
-                type: string
-              title: string_list
-              description: (proto string)
-            bytesList:
-              type: array
-              items:
-                type: string
-                format: byte
-              title: bytes_list
-              description: (proto bytes)
-            int32ToStringMap:
-              type: object
-              title: int32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: map key types (proto with_proto_annotations.test.v1.AllTypes.Int32ToStringMapEntry)
-            int64ToStringMap:
-              type: object
-              title: int64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Int64ToStringMapEntry)
-            uint32ToStringMap:
-              type: object
-              title: uint32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Uint32ToStringMapEntry)
-            uint64ToStringMap:
-              type: object
-              title: uint64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Uint64ToStringMapEntry)
-            sint32ToStringMap:
-              type: object
-              title: sint32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sint32ToStringMapEntry)
-            sint64ToStringMap:
-              type: object
-              title: sint64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sint64ToStringMapEntry)
-            fixed32ToStringMap:
-              type: object
-              title: fixed32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Fixed32ToStringMapEntry)
-            fixed64ToStringMap:
-              type: object
-              title: fixed64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Fixed64ToStringMapEntry)
-            sfixed32ToStringMap:
-              type: object
-              title: sfixed32_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed32ToStringMapEntry)
-            sfixed64ToStringMap:
-              type: object
-              title: sfixed64_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed64ToStringMapEntry)
-            boolToStringMap:
-              type: object
-              title: bool_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.BoolToStringMapEntry)
-            stringToStringMap:
-              type: object
-              title: string_to_string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.StringToStringMapEntry)
-            doubleMap:
-              type: object
-              title: double_map
-              additionalProperties:
-                type: number
-                title: value
-                format: double
-                description: (proto double)
-              description: map value types (proto with_proto_annotations.test.v1.AllTypes.DoubleMapEntry)
-            floatMap:
-              type: object
-              title: float_map
-              additionalProperties:
-                type: number
-                title: value
-                format: float
-                description: (proto float)
-              description: (proto with_proto_annotations.test.v1.AllTypes.FloatMapEntry)
-            int32Map:
-              type: object
-              title: int32_map
-              additionalProperties:
-                type: integer
-                title: value
-                format: int32
-                description: (proto int32)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Int32MapEntry)
-            int64Map:
-              type: object
-              title: int64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-                description: (proto int64)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Int64MapEntry)
-            uint32Map:
-              type: object
-              title: uint32_map
-              additionalProperties:
-                type: integer
-                title: value
-                description: (proto uint32)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Uint32MapEntry)
-            uint64Map:
-              type: object
-              title: uint64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-                description: (proto uint64)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Uint64MapEntry)
-            sint32Map:
-              type: object
-              title: sint32_map
-              additionalProperties:
-                type: integer
-                title: value
-                format: int32
-                description: (proto sint32)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sint32MapEntry)
-            sint64Map:
-              type: object
-              title: sint64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-                description: (proto sint64)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sint64MapEntry)
-            fixed32Map:
-              type: object
-              title: fixed32_map
-              additionalProperties:
-                type: integer
-                title: value
-                description: (proto fixed32)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Fixed32MapEntry)
-            fixed64Map:
-              type: object
-              title: fixed64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-                description: (proto fixed64)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Fixed64MapEntry)
-            sfixed32Map:
-              type: object
-              title: sfixed32_map
-              additionalProperties:
-                type: integer
-                title: value
-                format: int32
-                description: (proto sfixed32)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed32MapEntry)
-            sfixed64Map:
-              type: object
-              title: sfixed64_map
-              additionalProperties:
-                type: string
-                title: value
-                format: int64
-                description: (proto sfixed64)
-              description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed64MapEntry)
-            boolMap:
-              type: object
-              title: bool_map
-              additionalProperties:
-                type: boolean
-                title: value
-                description: (proto bool)
-              description: (proto with_proto_annotations.test.v1.AllTypes.BoolMapEntry)
-            stringMap:
-              type: object
-              title: string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: (proto with_proto_annotations.test.v1.AllTypes.StringMapEntry)
-            bytesMap:
-              type: object
-              title: bytes_map
-              additionalProperties:
-                type: string
-                title: value
-                format: byte
-                description: (proto bytes)
-              description: (proto with_proto_annotations.test.v1.AllTypes.BytesMapEntry)
-            optDoubleValue:
-              type:
-                - number
-                - "null"
-              title: opt_double_value
+          title: bytes_option
+        - type: object
+          properties:
+            doubleOption:
+              type: number
+              title: double_option
               format: double
-              description: explicit presence types (proto double)
-            optFloatValue:
-              type:
-                - number
-                - "null"
-              title: opt_float_value
+              description: (proto double)
+          title: double_option
+        - type: object
+          properties:
+            enumOption:
+              allOf:
+                - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
+              title: enum_option
+              description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+          title: enum_option
+        - type: object
+          properties:
+            fixed32Option:
+              type: integer
+              title: fixed32_option
+              description: (proto fixed32)
+          title: fixed32_option
+        - type: object
+          properties:
+            fixed64Option:
+              type: string
+              title: fixed64_option
+              format: int64
+              description: (proto fixed64)
+          title: fixed64_option
+        - type: object
+          properties:
+            floatOption:
+              type: number
+              title: float_option
               format: float
               description: (proto float)
-            optInt32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_int32_value
+          title: float_option
+        - type: object
+          properties:
+            int32Option:
+              type: integer
+              title: int32_option
               format: int32
               description: (proto int32)
-            optInt64Value:
-              type:
-                - string
-                - "null"
-              title: opt_int64_value
+          title: int32_option
+        - type: object
+          properties:
+            int64Option:
+              type: string
+              title: int64_option
               format: int64
               description: (proto int64)
-            optUint32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_uint32_value
-              description: (proto uint32)
-            optUint64Value:
-              type:
-                - string
-                - "null"
-              title: opt_uint64_value
-              format: int64
-              description: (proto uint64)
-            optSint32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_sint32_value
-              format: int32
-              description: (proto sint32)
-            optSint64Value:
-              type:
-                - string
-                - "null"
-              title: opt_sint64_value
-              format: int64
-              description: (proto sint64)
-            optFixed32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_fixed32_value
-              description: (proto fixed32)
-            optFixed64Value:
-              type:
-                - string
-                - "null"
-              title: opt_fixed64_value
-              format: int64
-              description: (proto fixed64)
-            optSfixed32Value:
-              type:
-                - integer
-                - "null"
-              title: opt_sfixed32_value
+          title: int64_option
+        - type: object
+          properties:
+            msgOption:
+              allOf:
+                - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
+              title: msg_option
+              description: (proto with_proto_annotations.test.v1.AllTypes)
+          title: msg_option
+        - type: object
+          properties:
+            sfixed32Option:
+              type: integer
+              title: sfixed32_option
               format: int32
               description: (proto sfixed32)
-            optSfixed64Value:
-              type:
-                - string
-                - "null"
-              title: opt_sfixed64_value
+          title: sfixed32_option
+        - type: object
+          properties:
+            sfixed64Option:
+              type: string
+              title: sfixed64_option
               format: int64
               description: (proto sfixed64)
-            optBoolValue:
-              type:
-                - boolean
-                - "null"
-              title: opt_bool_value
-              description: (proto bool)
-            optStringValue:
-              type:
-                - string
-                - "null"
-              title: opt_string_value
-              description: (proto string)
-            optBytesValue:
-              type:
-                - string
-                - "null"
-              title: opt_bytes_value
-              format: byte
-              description: (proto bytes)
-            msgValue:
-              allOf:
-                - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
-              title: msg_value
-              description: (proto with_proto_annotations.test.v1.AllTypes)
-            enumValue:
-              allOf:
-                - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
-              title: enum_value
-              description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
-            optMsgValue:
-              oneOf:
-                - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
-                - type: "null"
-              title: opt_msg_value
-              description: (proto with_proto_annotations.test.v1.AllTypes)
-            optEnumValue:
-              oneOf:
-                - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
-                - type: "null"
-              title: opt_enum_value
-              description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
-            msgList:
-              type: array
-              items:
-                $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
-              title: msg_list
-              description: (proto with_proto_annotations.test.v1.AllTypes)
-            enumList:
-              type: array
-              items:
-                $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
-              title: enum_list
-              description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
-            msgMap:
-              type: object
-              title: msg_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
-                title: value
-                description: (proto with_proto_annotations.test.v1.AllTypes)
-              description: (proto with_proto_annotations.test.v1.AllTypes.MsgMapEntry)
-            enumMap:
-              type: object
-              title: enum_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
-                title: value
-                description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
-              description: (proto with_proto_annotations.test.v1.AllTypes.EnumMapEntry)
-        - oneOf:
-            - type: object
-              properties:
-                boolOption:
-                  type: boolean
-                  title: bool_option
-                  description: (proto bool)
-              title: bool_option
-              required:
-                - boolOption
-            - type: object
-              properties:
-                bytesOption:
-                  type: string
-                  title: bytes_option
-                  format: byte
-                  description: (proto bytes)
-              title: bytes_option
-              required:
-                - bytesOption
-            - type: object
-              properties:
-                doubleOption:
-                  type: number
-                  title: double_option
-                  format: double
-                  description: (proto double)
-              title: double_option
-              required:
-                - doubleOption
-            - type: object
-              properties:
-                enumOption:
-                  allOf:
-                    - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
-                  title: enum_option
-                  description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
-              title: enum_option
-              required:
-                - enumOption
-            - type: object
-              properties:
-                fixed32Option:
-                  type: integer
-                  title: fixed32_option
-                  description: (proto fixed32)
-              title: fixed32_option
-              required:
-                - fixed32Option
-            - type: object
-              properties:
-                fixed64Option:
-                  type: string
-                  title: fixed64_option
-                  format: int64
-                  description: (proto fixed64)
-              title: fixed64_option
-              required:
-                - fixed64Option
-            - type: object
-              properties:
-                floatOption:
-                  type: number
-                  title: float_option
-                  format: float
-                  description: (proto float)
-              title: float_option
-              required:
-                - floatOption
-            - type: object
-              properties:
-                int32Option:
-                  type: integer
-                  title: int32_option
-                  format: int32
-                  description: (proto int32)
-              title: int32_option
-              required:
-                - int32Option
-            - type: object
-              properties:
-                int64Option:
-                  type: string
-                  title: int64_option
-                  format: int64
-                  description: (proto int64)
-              title: int64_option
-              required:
-                - int64Option
-            - type: object
-              properties:
-                msgOption:
-                  allOf:
-                    - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
-                  title: msg_option
-                  description: (proto with_proto_annotations.test.v1.AllTypes)
-              title: msg_option
-              required:
-                - msgOption
-            - type: object
-              properties:
-                sfixed32Option:
-                  type: integer
-                  title: sfixed32_option
-                  format: int32
-                  description: (proto sfixed32)
-              title: sfixed32_option
-              required:
-                - sfixed32Option
-            - type: object
-              properties:
-                sfixed64Option:
-                  type: string
-                  title: sfixed64_option
-                  format: int64
-                  description: (proto sfixed64)
-              title: sfixed64_option
-              required:
-                - sfixed64Option
-            - type: object
-              properties:
-                sint32Option:
-                  type: integer
-                  title: sint32_option
-                  format: int32
-                  description: (proto sint32)
+          title: sfixed64_option
+        - type: object
+          properties:
+            sint32Option:
+              type: integer
               title: sint32_option
-              required:
-                - sint32Option
-            - type: object
-              properties:
-                sint64Option:
-                  type: string
-                  title: sint64_option
-                  format: int64
-                  description: (proto sint64)
+              format: int32
+              description: (proto sint32)
+          title: sint32_option
+        - type: object
+          properties:
+            sint64Option:
+              type: string
               title: sint64_option
-              required:
-                - sint64Option
-            - type: object
-              properties:
-                stringOption:
-                  type: string
-                  title: string_option
-                  description: (proto string)
+              format: int64
+              description: (proto sint64)
+          title: sint64_option
+        - type: object
+          properties:
+            stringOption:
+              type: string
               title: string_option
-              required:
-                - stringOption
-            - type: object
-              properties:
-                uint32Option:
-                  type: integer
-                  title: uint32_option
-                  description: (proto uint32)
+              description: (proto string)
+          title: string_option
+        - type: object
+          properties:
+            uint32Option:
+              type: integer
               title: uint32_option
-              required:
-                - uint32Option
-            - type: object
-              properties:
-                uint64Option:
-                  type: string
-                  title: uint64_option
-                  format: int64
-                  description: (proto uint64)
+              description: (proto uint32)
+          title: uint32_option
+        - type: object
+          properties:
+            uint64Option:
+              type: string
               title: uint64_option
-              required:
-                - uint64Option
-            - not:
-                anyOf:
-                  - required:
-                      - boolOption
-                  - required:
-                      - bytesOption
-                  - required:
-                      - doubleOption
-                  - required:
-                      - enumOption
-                  - required:
-                      - fixed32Option
-                  - required:
-                      - fixed64Option
-                  - required:
-                      - floatOption
-                  - required:
-                      - int32Option
-                  - required:
-                      - int64Option
-                  - required:
-                      - msgOption
-                  - required:
-                      - sfixed32Option
-                  - required:
-                      - sfixed64Option
-                  - required:
-                      - sint32Option
-                  - required:
-                      - sint64Option
-                  - required:
-                      - stringOption
-                  - required:
-                      - uint32Option
-                  - required:
-                      - uint64Option
+              format: int64
+              description: (proto uint64)
+          title: uint64_option
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - boolOption
+              - required:
+                  - bytesOption
+              - required:
+                  - doubleOption
+              - required:
+                  - enumOption
+              - required:
+                  - fixed32Option
+              - required:
+                  - fixed64Option
+              - required:
+                  - floatOption
+              - required:
+                  - int32Option
+              - required:
+                  - int64Option
+              - required:
+                  - msgOption
+              - required:
+                  - sfixed32Option
+              - required:
+                  - sfixed64Option
+              - required:
+                  - sint32Option
+              - required:
+                  - sint64Option
+              - required:
+                  - stringOption
+              - required:
+                  - uint32Option
+              - required:
+                  - uint64Option
+          - not:
+              oneOf:
+                - required:
+                    - boolOption
+                - required:
+                    - bytesOption
+                - required:
+                    - doubleOption
+                - required:
+                    - enumOption
+                - required:
+                    - fixed32Option
+                - required:
+                    - fixed64Option
+                - required:
+                    - floatOption
+                - required:
+                    - int32Option
+                - required:
+                    - int64Option
+                - required:
+                    - msgOption
+                - required:
+                    - sfixed32Option
+                - required:
+                    - sfixed64Option
+                - required:
+                    - sint32Option
+                - required:
+                    - sint64Option
+                - required:
+                    - stringOption
+                - required:
+                    - uint32Option
+                - required:
+                    - uint64Option
+      properties:
+        doubleValue:
+          type: number
+          title: double_value
+          format: double
+          description: scalar types (proto double)
+        floatValue:
+          type: number
+          title: float_value
+          format: float
+          description: (proto float)
+        int32Value:
+          type: integer
+          title: int32_value
+          format: int32
+          description: (proto int32)
+        int64Value:
+          type: string
+          title: int64_value
+          format: int64
+          description: (proto int64)
+        uint32Value:
+          type: integer
+          title: uint32_value
+          description: (proto uint32)
+        uint64Value:
+          type: string
+          title: uint64_value
+          format: int64
+          description: (proto uint64)
+        sint32Value:
+          type: integer
+          title: sint32_value
+          format: int32
+          description: (proto sint32)
+        sint64Value:
+          type: string
+          title: sint64_value
+          format: int64
+          description: (proto sint64)
+        fixed32Value:
+          type: integer
+          title: fixed32_value
+          description: (proto fixed32)
+        fixed64Value:
+          type: string
+          title: fixed64_value
+          format: int64
+          description: (proto fixed64)
+        sfixed32Value:
+          type: integer
+          title: sfixed32_value
+          format: int32
+          description: (proto sfixed32)
+        sfixed64Value:
+          type: string
+          title: sfixed64_value
+          format: int64
+          description: (proto sfixed64)
+        boolValue:
+          type: boolean
+          title: bool_value
+          description: (proto bool)
+        stringValue:
+          type: string
+          title: string_value
+          description: (proto string)
+        bytesValue:
+          type: string
+          title: bytes_value
+          format: byte
+          description: (proto bytes)
+        doubleList:
+          type: array
+          items:
+            type: number
+            format: double
+          title: double_list
+          description: repeated types (proto double)
+        floatList:
+          type: array
+          items:
+            type: number
+            format: float
+          title: float_list
+          description: (proto float)
+        int32List:
+          type: array
+          items:
+            type: integer
+            format: int32
+          title: int32_list
+          description: (proto int32)
+        int64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: int64_list
+          description: (proto int64)
+        uint32List:
+          type: array
+          items:
+            type: integer
+          title: uint32_list
+          description: (proto uint32)
+        uint64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: uint64_list
+          description: (proto uint64)
+        sint32List:
+          type: array
+          items:
+            type: integer
+            format: int32
+          title: sint32_list
+          description: (proto sint32)
+        sint64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: sint64_list
+          description: (proto sint64)
+        fixed32List:
+          type: array
+          items:
+            type: integer
+          title: fixed32_list
+          description: (proto fixed32)
+        fixed64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: fixed64_list
+          description: (proto fixed64)
+        sfixed32List:
+          type: array
+          items:
+            type: integer
+            format: int32
+          title: sfixed32_list
+          description: (proto sfixed32)
+        sfixed64List:
+          type: array
+          items:
+            type: string
+            format: int64
+          title: sfixed64_list
+          description: (proto sfixed64)
+        boolList:
+          type: array
+          items:
+            type: boolean
+          title: bool_list
+          description: (proto bool)
+        stringList:
+          type: array
+          items:
+            type: string
+          title: string_list
+          description: (proto string)
+        bytesList:
+          type: array
+          items:
+            type: string
+            format: byte
+          title: bytes_list
+          description: (proto bytes)
+        int32ToStringMap:
+          type: object
+          title: int32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: map key types (proto with_proto_annotations.test.v1.AllTypes.Int32ToStringMapEntry)
+        int64ToStringMap:
+          type: object
+          title: int64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Int64ToStringMapEntry)
+        uint32ToStringMap:
+          type: object
+          title: uint32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Uint32ToStringMapEntry)
+        uint64ToStringMap:
+          type: object
+          title: uint64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Uint64ToStringMapEntry)
+        sint32ToStringMap:
+          type: object
+          title: sint32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sint32ToStringMapEntry)
+        sint64ToStringMap:
+          type: object
+          title: sint64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sint64ToStringMapEntry)
+        fixed32ToStringMap:
+          type: object
+          title: fixed32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Fixed32ToStringMapEntry)
+        fixed64ToStringMap:
+          type: object
+          title: fixed64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Fixed64ToStringMapEntry)
+        sfixed32ToStringMap:
+          type: object
+          title: sfixed32_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed32ToStringMapEntry)
+        sfixed64ToStringMap:
+          type: object
+          title: sfixed64_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed64ToStringMapEntry)
+        boolToStringMap:
+          type: object
+          title: bool_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.BoolToStringMapEntry)
+        stringToStringMap:
+          type: object
+          title: string_to_string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.StringToStringMapEntry)
+        doubleMap:
+          type: object
+          title: double_map
+          additionalProperties:
+            type: number
+            title: value
+            format: double
+            description: (proto double)
+          description: map value types (proto with_proto_annotations.test.v1.AllTypes.DoubleMapEntry)
+        floatMap:
+          type: object
+          title: float_map
+          additionalProperties:
+            type: number
+            title: value
+            format: float
+            description: (proto float)
+          description: (proto with_proto_annotations.test.v1.AllTypes.FloatMapEntry)
+        int32Map:
+          type: object
+          title: int32_map
+          additionalProperties:
+            type: integer
+            title: value
+            format: int32
+            description: (proto int32)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Int32MapEntry)
+        int64Map:
+          type: object
+          title: int64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+            description: (proto int64)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Int64MapEntry)
+        uint32Map:
+          type: object
+          title: uint32_map
+          additionalProperties:
+            type: integer
+            title: value
+            description: (proto uint32)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Uint32MapEntry)
+        uint64Map:
+          type: object
+          title: uint64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+            description: (proto uint64)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Uint64MapEntry)
+        sint32Map:
+          type: object
+          title: sint32_map
+          additionalProperties:
+            type: integer
+            title: value
+            format: int32
+            description: (proto sint32)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sint32MapEntry)
+        sint64Map:
+          type: object
+          title: sint64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+            description: (proto sint64)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sint64MapEntry)
+        fixed32Map:
+          type: object
+          title: fixed32_map
+          additionalProperties:
+            type: integer
+            title: value
+            description: (proto fixed32)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Fixed32MapEntry)
+        fixed64Map:
+          type: object
+          title: fixed64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+            description: (proto fixed64)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Fixed64MapEntry)
+        sfixed32Map:
+          type: object
+          title: sfixed32_map
+          additionalProperties:
+            type: integer
+            title: value
+            format: int32
+            description: (proto sfixed32)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed32MapEntry)
+        sfixed64Map:
+          type: object
+          title: sfixed64_map
+          additionalProperties:
+            type: string
+            title: value
+            format: int64
+            description: (proto sfixed64)
+          description: (proto with_proto_annotations.test.v1.AllTypes.Sfixed64MapEntry)
+        boolMap:
+          type: object
+          title: bool_map
+          additionalProperties:
+            type: boolean
+            title: value
+            description: (proto bool)
+          description: (proto with_proto_annotations.test.v1.AllTypes.BoolMapEntry)
+        stringMap:
+          type: object
+          title: string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: (proto with_proto_annotations.test.v1.AllTypes.StringMapEntry)
+        bytesMap:
+          type: object
+          title: bytes_map
+          additionalProperties:
+            type: string
+            title: value
+            format: byte
+            description: (proto bytes)
+          description: (proto with_proto_annotations.test.v1.AllTypes.BytesMapEntry)
+        optDoubleValue:
+          type:
+            - number
+            - "null"
+          title: opt_double_value
+          format: double
+          description: explicit presence types (proto double)
+        optFloatValue:
+          type:
+            - number
+            - "null"
+          title: opt_float_value
+          format: float
+          description: (proto float)
+        optInt32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_int32_value
+          format: int32
+          description: (proto int32)
+        optInt64Value:
+          type:
+            - string
+            - "null"
+          title: opt_int64_value
+          format: int64
+          description: (proto int64)
+        optUint32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_uint32_value
+          description: (proto uint32)
+        optUint64Value:
+          type:
+            - string
+            - "null"
+          title: opt_uint64_value
+          format: int64
+          description: (proto uint64)
+        optSint32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_sint32_value
+          format: int32
+          description: (proto sint32)
+        optSint64Value:
+          type:
+            - string
+            - "null"
+          title: opt_sint64_value
+          format: int64
+          description: (proto sint64)
+        optFixed32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_fixed32_value
+          description: (proto fixed32)
+        optFixed64Value:
+          type:
+            - string
+            - "null"
+          title: opt_fixed64_value
+          format: int64
+          description: (proto fixed64)
+        optSfixed32Value:
+          type:
+            - integer
+            - "null"
+          title: opt_sfixed32_value
+          format: int32
+          description: (proto sfixed32)
+        optSfixed64Value:
+          type:
+            - string
+            - "null"
+          title: opt_sfixed64_value
+          format: int64
+          description: (proto sfixed64)
+        optBoolValue:
+          type:
+            - boolean
+            - "null"
+          title: opt_bool_value
+          description: (proto bool)
+        optStringValue:
+          type:
+            - string
+            - "null"
+          title: opt_string_value
+          description: (proto string)
+        optBytesValue:
+          type:
+            - string
+            - "null"
+          title: opt_bytes_value
+          format: byte
+          description: (proto bytes)
+        msgValue:
+          allOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
+          title: msg_value
+          description: (proto with_proto_annotations.test.v1.AllTypes)
+        enumValue:
+          allOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
+          title: enum_value
+          description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+        optMsgValue:
+          oneOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
+            - type: "null"
+          title: opt_msg_value
+          description: (proto with_proto_annotations.test.v1.AllTypes)
+        optEnumValue:
+          oneOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
+            - type: "null"
+          title: opt_enum_value
+          description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+        msgList:
+          type: array
+          items:
+            $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
+          title: msg_list
+          description: (proto with_proto_annotations.test.v1.AllTypes)
+        enumList:
+          type: array
+          items:
+            $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
+          title: enum_list
+          description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+        msgMap:
+          type: object
+          title: msg_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes'
+            title: value
+            description: (proto with_proto_annotations.test.v1.AllTypes)
+          description: (proto with_proto_annotations.test.v1.AllTypes.MsgMapEntry)
+        enumMap:
+          type: object
+          title: enum_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/with_proto_annotations.test.v1.AllTypes.Enum'
+            title: value
+            description: (proto with_proto_annotations.test.v1.AllTypes.Enum)
+          description: (proto with_proto_annotations.test.v1.AllTypes.EnumMapEntry)
       title: AllTypes
     with_proto_annotations.test.v1.AllTypes.Enum:
       type: string
@@ -857,264 +859,266 @@ components:
       description: named types
     with_proto_annotations.test.v1.ParameterValues:
       type: object
-      allOf:
-        - properties:
-            doubleValue:
+      anyOf:
+        - type: object
+          properties:
+            oneofDoubleValue:
               type: number
-              title: double_value
+              title: oneof_double_value
               format: double
-              description: scalar types (proto double)
-            floatValue:
-              type: number
-              title: float_value
-              format: float
-              description: (proto float)
-            int32Value:
-              type: integer
-              title: int32_value
-              format: int32
-              description: (proto int32)
-            int64Value:
-              type: string
-              title: int64_value
-              format: int64
-              description: (proto int64)
-            uint32Value:
-              type: integer
-              title: uint32_value
-              description: (proto uint32)
-            uint64Value:
-              type: string
-              title: uint64_value
-              format: int64
-              description: (proto uint64)
-            sint32Value:
-              type: integer
-              title: sint32_value
-              format: int32
-              description: (proto sint32)
-            sint64Value:
-              type: string
-              title: sint64_value
-              format: int64
-              description: (proto sint64)
-            fixed32Value:
-              type: integer
-              title: fixed32_value
-              description: (proto fixed32)
-            fixed64Value:
-              type: string
-              title: fixed64_value
-              format: int64
-              description: (proto fixed64)
-            sfixed32Value:
-              type: integer
-              title: sfixed32_value
-              format: int32
-              description: (proto sfixed32)
-            sfixed64Value:
-              type: string
-              title: sfixed64_value
-              format: int64
-              description: (proto sfixed64)
-            boolValue:
-              type: boolean
-              title: bool_value
-              description: (proto bool)
-            stringValue:
-              type: string
-              title: string_value
-              description: (proto string)
-            bytesValue:
-              type: string
-              title: bytes_value
-              format: byte
-              description: (proto bytes)
-            timestamp:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Timestamp'
-              title: timestamp
-              description: scalar wrappers (proto google.protobuf.Timestamp)
-            duration:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Duration'
-              title: duration
-              description: (proto google.protobuf.Duration)
-            boolValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.BoolValue'
-              title: bool_value_wrapper
-              description: (proto google.protobuf.BoolValue)
-            int32ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Int32Value'
-              title: int32_value_wrapper
-              description: (proto google.protobuf.Int32Value)
-            int64ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Int64Value'
-              title: int64_value_wrapper
-              description: (proto google.protobuf.Int64Value)
-            uint32ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.UInt32Value'
-              title: uint32_value_wrapper
-              description: (proto google.protobuf.UInt32Value)
-            uint64ValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.UInt64Value'
-              title: uint64_value_wrapper
-              description: (proto google.protobuf.UInt64Value)
-            floatValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.FloatValue'
-              title: float_value_wrapper
-              description: (proto google.protobuf.FloatValue)
-            doubleValueWrapper:
+              description: (proto double)
+          title: oneof_double_value
+        - type: object
+          properties:
+            oneofDoubleValueWrapper:
               allOf:
                 - $ref: '#/components/schemas/google.protobuf.DoubleValue'
-              title: double_value_wrapper
+              title: oneof_double_value_wrapper
               description: (proto google.protobuf.DoubleValue)
-            bytesValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.BytesValue'
-              title: bytes_value_wrapper
-              description: (proto google.protobuf.BytesValue)
-            stringValueWrapper:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.StringValue'
-              title: string_value_wrapper
-              description: (proto google.protobuf.StringValue)
-            fieldMask:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.FieldMask'
-              title: field_mask
-              description: (proto google.protobuf.FieldMask)
-            enumValue:
+          title: oneof_double_value_wrapper
+        - type: object
+          properties:
+            oneofEnumValue:
               allOf:
                 - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
-              title: enum_value
-              description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
-            enumList:
-              type: array
-              items:
-                $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
-              title: enum_list
-              description: complex types (proto with_proto_annotations.test.v1.ParameterValues.Enum)
-            doubleList:
-              type: array
-              items:
-                type: number
-                format: double
-              title: double_list
-              description: (proto double)
-            doubleValueList:
-              type: array
-              items:
-                $ref: '#/components/schemas/google.protobuf.DoubleValue'
-              title: double_value_list
-              description: (proto google.protobuf.DoubleValue)
-            nested:
-              allOf:
-                - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested'
-              title: nested
-              description: (proto with_proto_annotations.test.v1.ParameterValues.Nested)
-            recursive:
-              allOf:
-                - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues'
-              title: recursive
-              description: (proto with_proto_annotations.test.v1.ParameterValues)
-            stringMap:
-              type: object
-              title: string_map
-              additionalProperties:
-                type: string
-                title: value
-                description: (proto string)
-              description: unsupported (proto with_proto_annotations.test.v1.ParameterValues.StringMapEntry)
-            stringValueMap:
-              type: object
-              title: string_value_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/google.protobuf.StringValue'
-                title: value
-                description: (proto google.protobuf.StringValue)
-              description: (proto with_proto_annotations.test.v1.ParameterValues.StringValueMapEntry)
-            enumMap:
-              type: object
-              title: enum_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
-                title: value
-                description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
-              description: (proto with_proto_annotations.test.v1.ParameterValues.EnumMapEntry)
-            nestedMap:
-              type: object
-              title: nested_map
-              additionalProperties:
-                allOf:
-                  - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested'
-                title: value
-                description: (proto with_proto_annotations.test.v1.ParameterValues.Nested)
-              description: (proto with_proto_annotations.test.v1.ParameterValues.NestedMapEntry)
-            structValue:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Struct'
-              title: struct_value
-              description: (proto google.protobuf.Struct)
-            value:
-              allOf:
-                - $ref: '#/components/schemas/google.protobuf.Value'
-              title: value
-              description: (proto google.protobuf.Value)
-            recursiveList:
-              type: array
-              items:
-                $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues'
-              title: recursive_list
-              description: (proto with_proto_annotations.test.v1.ParameterValues)
-        - oneOf:
-            - type: object
-              properties:
-                oneofDoubleValue:
-                  type: number
-                  title: oneof_double_value
-                  format: double
-                  description: (proto double)
-              title: oneof_double_value
-              required:
-                - oneofDoubleValue
-            - type: object
-              properties:
-                oneofDoubleValueWrapper:
-                  allOf:
-                    - $ref: '#/components/schemas/google.protobuf.DoubleValue'
-                  title: oneof_double_value_wrapper
-                  description: (proto google.protobuf.DoubleValue)
-              title: oneof_double_value_wrapper
-              required:
-                - oneofDoubleValueWrapper
-            - type: object
-              properties:
-                oneofEnumValue:
-                  allOf:
-                    - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
-                  title: oneof_enum_value
-                  description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
               title: oneof_enum_value
-              required:
-                - oneofEnumValue
-            - not:
-                anyOf:
-                  - required:
-                      - oneofDoubleValue
-                  - required:
-                      - oneofDoubleValueWrapper
-                  - required:
-                      - oneofEnumValue
+              description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
+          title: oneof_enum_value
       unevaluatedProperties: false
+      not:
+        allOf:
+          - anyOf:
+              - required:
+                  - oneofDoubleValue
+              - required:
+                  - oneofDoubleValueWrapper
+              - required:
+                  - oneofEnumValue
+          - not:
+              oneOf:
+                - required:
+                    - oneofDoubleValue
+                - required:
+                    - oneofDoubleValueWrapper
+                - required:
+                    - oneofEnumValue
+      properties:
+        doubleValue:
+          type: number
+          title: double_value
+          format: double
+          description: scalar types (proto double)
+        floatValue:
+          type: number
+          title: float_value
+          format: float
+          description: (proto float)
+        int32Value:
+          type: integer
+          title: int32_value
+          format: int32
+          description: (proto int32)
+        int64Value:
+          type: string
+          title: int64_value
+          format: int64
+          description: (proto int64)
+        uint32Value:
+          type: integer
+          title: uint32_value
+          description: (proto uint32)
+        uint64Value:
+          type: string
+          title: uint64_value
+          format: int64
+          description: (proto uint64)
+        sint32Value:
+          type: integer
+          title: sint32_value
+          format: int32
+          description: (proto sint32)
+        sint64Value:
+          type: string
+          title: sint64_value
+          format: int64
+          description: (proto sint64)
+        fixed32Value:
+          type: integer
+          title: fixed32_value
+          description: (proto fixed32)
+        fixed64Value:
+          type: string
+          title: fixed64_value
+          format: int64
+          description: (proto fixed64)
+        sfixed32Value:
+          type: integer
+          title: sfixed32_value
+          format: int32
+          description: (proto sfixed32)
+        sfixed64Value:
+          type: string
+          title: sfixed64_value
+          format: int64
+          description: (proto sfixed64)
+        boolValue:
+          type: boolean
+          title: bool_value
+          description: (proto bool)
+        stringValue:
+          type: string
+          title: string_value
+          description: (proto string)
+        bytesValue:
+          type: string
+          title: bytes_value
+          format: byte
+          description: (proto bytes)
+        timestamp:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Timestamp'
+          title: timestamp
+          description: scalar wrappers (proto google.protobuf.Timestamp)
+        duration:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Duration'
+          title: duration
+          description: (proto google.protobuf.Duration)
+        boolValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.BoolValue'
+          title: bool_value_wrapper
+          description: (proto google.protobuf.BoolValue)
+        int32ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Int32Value'
+          title: int32_value_wrapper
+          description: (proto google.protobuf.Int32Value)
+        int64ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Int64Value'
+          title: int64_value_wrapper
+          description: (proto google.protobuf.Int64Value)
+        uint32ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.UInt32Value'
+          title: uint32_value_wrapper
+          description: (proto google.protobuf.UInt32Value)
+        uint64ValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.UInt64Value'
+          title: uint64_value_wrapper
+          description: (proto google.protobuf.UInt64Value)
+        floatValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.FloatValue'
+          title: float_value_wrapper
+          description: (proto google.protobuf.FloatValue)
+        doubleValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.DoubleValue'
+          title: double_value_wrapper
+          description: (proto google.protobuf.DoubleValue)
+        bytesValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.BytesValue'
+          title: bytes_value_wrapper
+          description: (proto google.protobuf.BytesValue)
+        stringValueWrapper:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.StringValue'
+          title: string_value_wrapper
+          description: (proto google.protobuf.StringValue)
+        fieldMask:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.FieldMask'
+          title: field_mask
+          description: (proto google.protobuf.FieldMask)
+        enumValue:
+          allOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
+          title: enum_value
+          description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
+        enumList:
+          type: array
+          items:
+            $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
+          title: enum_list
+          description: complex types (proto with_proto_annotations.test.v1.ParameterValues.Enum)
+        doubleList:
+          type: array
+          items:
+            type: number
+            format: double
+          title: double_list
+          description: (proto double)
+        doubleValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/google.protobuf.DoubleValue'
+          title: double_value_list
+          description: (proto google.protobuf.DoubleValue)
+        nested:
+          allOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested'
+          title: nested
+          description: (proto with_proto_annotations.test.v1.ParameterValues.Nested)
+        recursive:
+          allOf:
+            - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues'
+          title: recursive
+          description: (proto with_proto_annotations.test.v1.ParameterValues)
+        stringMap:
+          type: object
+          title: string_map
+          additionalProperties:
+            type: string
+            title: value
+            description: (proto string)
+          description: unsupported (proto with_proto_annotations.test.v1.ParameterValues.StringMapEntry)
+        stringValueMap:
+          type: object
+          title: string_value_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/google.protobuf.StringValue'
+            title: value
+            description: (proto google.protobuf.StringValue)
+          description: (proto with_proto_annotations.test.v1.ParameterValues.StringValueMapEntry)
+        enumMap:
+          type: object
+          title: enum_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Enum'
+            title: value
+            description: (proto with_proto_annotations.test.v1.ParameterValues.Enum)
+          description: (proto with_proto_annotations.test.v1.ParameterValues.EnumMapEntry)
+        nestedMap:
+          type: object
+          title: nested_map
+          additionalProperties:
+            allOf:
+              - $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues.Nested'
+            title: value
+            description: (proto with_proto_annotations.test.v1.ParameterValues.Nested)
+          description: (proto with_proto_annotations.test.v1.ParameterValues.NestedMapEntry)
+        structValue:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Struct'
+          title: struct_value
+          description: (proto google.protobuf.Struct)
+        value:
+          allOf:
+            - $ref: '#/components/schemas/google.protobuf.Value'
+          title: value
+          description: (proto google.protobuf.Value)
+        recursiveList:
+          type: array
+          items:
+            $ref: '#/components/schemas/with_proto_annotations.test.v1.ParameterValues'
+          title: recursive_list
+          description: (proto with_proto_annotations.test.v1.ParameterValues)
       title: ParameterValues
     with_proto_annotations.test.v1.ParameterValues.Enum:
       type: string


### PR DESCRIPTION
This fixes a an issue introduced in #264.

While that PR introduced a fix to match protobuf's expected `oneof` at-most-once behavior, it did so by introducing an extra, untitled branch that resulted in a phantom variant in documentation renderers (e.g. Mintlify).

An alternative way of expressing the same rule is to have a sibling `not` rule which is seemingly ignored by doc renderers.

Additionally, the member properties now stay at the root of the message schema, which leaves nothing to merge into allOf and nothing for the request body to recover from there, so both are gone.