### PR TITLE
fix(schema): let gnostic type annotations replace generated refs

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -848,3 +848,59 @@ func TestWrapRefsInAllOf(t *testing.T) {
 	require.Len(t, allOf, 1)
 	assert.Equal(t, "#/components/schemas/test.Child", allOf[0].(map[string]any)["$ref"])
 }
+
+// TestJSONSchemaGnosticPropertyOverride checks that a gnostic property
+// annotation describing a field's own type replaces the generated $ref rather
+// than being combined with it.
+//
+// Before this was fixed, an annotated message- or enum-typed field kept both
+// the annotation's type and the $ref to the referenced definition. The two
+// contradict, so the property accepted no value at all.
+func TestJSONSchemaGnosticPropertyOverride(t *testing.T) {
+	content := generateAndCheckResult(t, "", "jsonschema", "testdata/jsonschema/gnostic_override.proto")
+	compiler := compileJSONSchema(t, content)
+
+	recordSchema, err := compiler.Compile("schema.json#/$defs/gnosticoverride.Record")
+	require.NoError(t, err)
+
+	// The annotated fields accept the form the annotation documents.
+	annotated, err := jsonschemavalidator.UnmarshalJSON(strings.NewReader(`{
+		"id": "r-1",
+		"startDate": "2024-01-15",
+		"status": "active",
+		"retiredOn": "2025-06-30",
+		"plainDate": {"year": 2024, "month": 1, "day": 15},
+		"plainStatus": "STATUS_ACTIVE",
+		"titledOnly": {"year": 2024, "month": 1, "day": 15}
+	}`))
+	require.NoError(t, err)
+	assert.NoError(t, recordSchema.Validate(annotated))
+
+	// An annotated field no longer accepts the underlying message's own form.
+	wrongShape, err := jsonschemavalidator.UnmarshalJSON(strings.NewReader(
+		`{"id": "r-1", "startDate": {"year": 2024, "month": 1, "day": 15}}`))
+	require.NoError(t, err)
+	assert.Error(t, recordSchema.Validate(wrongShape),
+		"an annotated date should not accept the google.type.Date object form")
+
+	// The annotation's vocabulary is enforced, not the generated enum's.
+	wrongEnum, err := jsonschemavalidator.UnmarshalJSON(strings.NewReader(
+		`{"id": "r-1", "startDate": "2024-01-15", "status": "STATUS_ACTIVE"}`))
+	require.NoError(t, err)
+	assert.Error(t, recordSchema.Validate(wrongEnum),
+		"an annotated enum should enforce the annotated values")
+
+	// A field with no annotation, and one whose annotation sets no type, both
+	// keep the generated reference.
+	assert.Contains(t, content, `"$ref": "#/$defs/google.type.Date"`)
+	assert.Contains(t, content, `"$ref": "#/$defs/gnosticoverride.Status"`)
+
+	// Resolving the reference has a side effect on the parent: protovalidate
+	// contributes start_date to the required list. Skipping the resolution
+	// rather than the attachment would silently drop it.
+	recordRequired, err := jsonschemavalidator.UnmarshalJSON(strings.NewReader(
+		`{"id": "r-1", "status": "active"}`))
+	require.NoError(t, err)
+	assert.Error(t, recordSchema.Validate(recordRequired),
+		"start_date is protovalidate-required, so omitting it must fail")
+}

--- a/internal/converter/schema/schema.go
+++ b/internal/converter/schema/schema.go
@@ -166,14 +166,19 @@ func FieldToSchema(opts options.Options, parent *base.SchemaProxy, tt protorefle
 		switch tt.Kind() {
 		case protoreflect.MessageKind, protoreflect.EnumKind:
 			msg := ScalarFieldToSchema(opts, parent, tt, false)
+			// Resolve the reference even when it will not be attached below:
+			// it annotates the *parent* with protovalidate-derived properties,
+			// which is independent of how this field describes itself.
 			ref := ReferenceFieldToSchema(opts, parent, tt)
-			if tt.HasOptionalKeyword() {
-				msg.OneOf = []*base.SchemaProxy{
-					ref,
-					base.CreateSchemaProxy(&base.Schema{Type: []string{"null"}}),
+			if !describesType(msg) {
+				if tt.HasOptionalKeyword() {
+					msg.OneOf = []*base.SchemaProxy{
+						ref,
+						base.CreateSchemaProxy(&base.Schema{Type: []string{"null"}}),
+					}
+				} else {
+					msg.AllOf = []*base.SchemaProxy{ref}
 				}
-			} else {
-				msg.AllOf = []*base.SchemaProxy{ref}
 			}
 			return base.CreateSchemaProxy(msg)
 		}
@@ -181,6 +186,18 @@ func FieldToSchema(opts options.Options, parent *base.SchemaProxy, tt protorefle
 		s := ScalarFieldToSchema(opts, parent, tt, false)
 		return base.CreateSchemaProxy(s)
 	}
+}
+
+// describesType reports whether an annotation has already given a field a
+// complete type of its own.
+//
+// ScalarFieldToSchema leaves all four of these empty for a message or enum
+// kind, so a non-empty one can only have come from a gnostic annotation. When
+// the field describes itself, attaching the generated $ref as well produces a
+// schema that contradicts the annotation and accepts no value at all.
+func describesType(s *base.Schema) bool {
+	return len(s.Type) > 0 || len(s.AllOf) > 0 ||
+		len(s.OneOf) > 0 || len(s.AnyOf) > 0
 }
 
 func ScalarFieldToSchema(opts options.Options, parent *base.SchemaProxy, tt protoreflect.FieldDescriptor, inContainer bool) *base.Schema {

--- a/internal/converter/testdata/jsonschema/gnostic_override.proto
+++ b/internal/converter/testdata/jsonschema/gnostic_override.proto
@@ -1,0 +1,61 @@
+// A file for testing that a gnostic property annotation describing a field's
+// own type replaces the generated $ref instead of contradicting it.
+syntax = "proto3";
+
+package gnosticoverride;
+
+import "buf/validate/validate.proto";
+import "gnostic/openapi/v3/annotations.proto";
+import "google/type/date.proto";
+
+// Status is a generated enum whose values carry a protobuf-style prefix.
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STATUS_ACTIVE = 1;
+  STATUS_TOBEDELETED = 2;
+}
+
+// Record exercises every shape the message/enum branch of FieldToSchema can
+// take, with and without an annotation.
+message Record {
+  // id is an ordinary scalar, unaffected by this branch.
+  string id = 1 [(buf.validate.field).string.min_len = 1];
+
+  // start_date is a calendar date modelled as google.type.Date but documented
+  // in its original wire form. It is also protovalidate-required, so the
+  // parent's required list proves the reference is still *resolved* even
+  // though it is no longer *attached*.
+  google.type.Date start_date = 2 [
+    (buf.validate.field).required = true,
+    (gnostic.openapi.v3.property) = {
+      type: "string"
+      format: "date"
+    }
+  ];
+
+  // status is a generated enum documented with the vocabulary the source
+  // schema actually used.
+  Status status = 3 [(gnostic.openapi.v3.property) = {
+    type: "string"
+    enum: [
+      {yaml: "active"},
+      {yaml: "tobedeleted"}
+    ]
+  }];
+
+  // retired_on is optional and annotated, so the oneOf branch is exercised.
+  optional google.type.Date retired_on = 4 [(gnostic.openapi.v3.property) = {
+    type: "string"
+    format: "date"
+  }];
+
+  // plain_date carries no annotation and must keep the generated reference.
+  google.type.Date plain_date = 5;
+
+  // plain_status carries no annotation and must keep the generated reference.
+  Status plain_status = 6;
+
+  // titled_only annotates something other than a type, so the reference must
+  // still be attached.
+  google.type.Date titled_only = 7 [(gnostic.openapi.v3.property) = {title: "A titled date"}];
+}

--- a/internal/converter/testdata/jsonschema/output/gnostic_override.jsonschema.json
+++ b/internal/converter/testdata/jsonschema/output/gnostic_override.jsonschema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "gnosticoverride.Record": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "id",
+          "minLength": 1,
+          "description": "id is an ordinary scalar, unaffected by this branch."
+        },
+        "startDate": {
+          "type": "string",
+          "title": "start_date",
+          "format": "date",
+          "description": "start_date is a calendar date modelled as google.type.Date but documented\n in its original wire form. It is also protovalidate-required, so the\n parent's required list proves the reference is still *resolved* even\n though it is no longer *attached*."
+        },
+        "status": {
+          "type": "string",
+          "title": "status",
+          "enum": [
+            "active",
+            "tobedeleted"
+          ],
+          "description": "status is a generated enum documented with the vocabulary the source\n schema actually used."
+        },
+        "retiredOn": {
+          "type": "string",
+          "title": "retired_on",
+          "format": "date",
+          "description": "retired_on is optional and annotated, so the oneOf branch is exercised."
+        },
+        "plainDate": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/google.type.Date"
+            }
+          ],
+          "title": "plain_date",
+          "description": "plain_date carries no annotation and must keep the generated reference."
+        },
+        "plainStatus": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/gnosticoverride.Status"
+            }
+          ],
+          "title": "plain_status",
+          "description": "plain_status carries no annotation and must keep the generated reference."
+        },
+        "titledOnly": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/google.type.Date"
+            }
+          ],
+          "title": "A titled date",
+          "description": "titled_only annotates something other than a type, so the reference must\n still be attached."
+        }
+      },
+      "title": "Record",
+      "required": [
+        "startDate"
+      ],
+      "additionalProperties": false,
+      "description": "Record exercises every shape the message/enum branch of FieldToSchema can\n take, with and without an annotation."
+    },
+    "gnosticoverride.Status": {
+      "type": "string",
+      "title": "Status",
+      "enum": [
+        "STATUS_UNSPECIFIED",
+        "STATUS_ACTIVE",
+        "STATUS_TOBEDELETED"
+      ],
+      "description": "Status is a generated enum whose values carry a protobuf-style prefix."
+    },
+    "google.type.Date": {
+      "type": "object",
+      "properties": {
+        "year": {
+          "type": "integer",
+          "title": "year",
+          "format": "int32",
+          "description": "Year of the date. Must be from 1 to 9999, or 0 to specify a date without\n a year."
+        },
+        "month": {
+          "type": "integer",
+          "title": "month",
+          "format": "int32",
+          "description": "Month of a year. Must be from 1 to 12, or 0 to specify a year without a\n month and day."
+        },
+        "day": {
+          "type": "integer",
+          "title": "day",
+          "format": "int32",
+          "description": "Day of a month. Must be from 1 to 31 and valid for the year and month, or 0\n to specify a year by itself or a year and month where the day isn't\n significant."
+        }
+      },
+      "title": "Date",
+      "additionalProperties": false,
+      "description": "Represents a whole or partial calendar date, such as a birthday. The time of\n day and time zone are either specified elsewhere or are insignificant. The\n date is relative to the Gregorian Calendar. This can represent one of the\n following:\n\n * A full date, with non-zero year, month, and day values\n * A month and day value, with a zero year, such as an anniversary\n * A year on its own, with zero month and day values\n * A year and month value, with a zero day, such as a credit card expiration\n date\n\n Related types are [google.type.TimeOfDay][google.type.TimeOfDay] and\n `google.protobuf.Timestamp`."
+    }
+  }
+}


### PR DESCRIPTION
Hi, thanks for making cool stuff. I ran into some issues, so I decided to roundtrip Protobuf to JSON Schema to Protobuf and use property based testing (with [Rapid](https://github.com/flyingmutant/rapid)), and found where things broke down, and this is one way to fix it.

## Summary
A `(gnostic.openapi.v3.property)` annotation on a `message`-type or `enum`-typed field is
applied and then partly overwritten. The field keeps the annotation's `type`,
`format`, and `enum` **and** the generated `$ref`. Those contradict, so the
property accepts no value at all.

### Repro

```protobuf
google.type.Date start_date = 1 [(gnostic.openapi.v3.property) = {
  type: "string"
  format: "date"
}];
```

`format=jsonschema` emits:

```json
"startDate": {
  "type": "string",
  "format": "date",
  "allOf": [{ "$ref": "#/$defs/google.type.Date" }]
}
```

Validated with `santhosh-tekuri/jsonschema` v6: `"2024-01-15"` fails `allOf`
(*got string, want object*) and `{"year":2024,...}` fails `type` (*got object,
want string*). Nothing validates — strictly worse than omitting the annotation,
which at least accepts the protobuf form. An annotated enum fails symmetrically.

### Fix

`FieldToSchema` attaches the generated reference only when the annotation has
not already given the field a complete type.

The reference is still *resolved* either way, because `ReferenceFieldToSchema`
annotates the parent with protovalidate-derived `required` entries that are
independent of how the field describes itself. Skipping the call rather than
the attachment would drop those silently.

### Verification

- `testdata/jsonschema/gnostic_override.proto` covers annotated message, enum,
  and `optional` fields, un-annotated controls, and an annotation that sets only
  `title` (which must keep its `$ref`).
- A new instance-validation test asserts the annotated date accepts
  `"2024-01-15"` and rejects the object form, and that the annotated enum
  enforces its own vocabulary.
- The parent's `required` list still receives the `protovalidate` entry for an
  annotated field.
- **All 135 existing golden files are byte-identical.**
- `just generate test` passes; `golangci-lint run ./...` issue count is
  unchanged at 783.

Reverting the guard makes the new test fail.
